### PR TITLE
Repair Fibonacci heap priority semantics

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -23,6 +23,7 @@
 - [Base] Corrected LU singularity detection for final pivots and 1x1 matrices
 - [Base] Corrected integer GCD and LCM sign, zero, and overflow semantics
 - [Base] Corrected and accelerated integer primality checks
+- [Base] Corrected and accelerated Fibonacci-heap priority ordering and cascading cuts for shortest paths
 - [Geometry] Corrected `PolyRegion` containment for holes, nested contours, boundaries, and reversed orientations
 ### 5.3.28-prerelease0001
 - [Base] Corrected ray projection and closest-distance parameters for non-unit, degenerate, and extreme finite directions

--- a/ai/ALGORITHMS.md
+++ b/ai/ALGORITHMS.md
@@ -12,6 +12,15 @@ so they continue to observe the last completed result while a replacement is run
 invalidates, cancels, and waits for the current run; expected cancellation is suppressed while
 worker failures are propagated.
 
+Costs must be finite and non-negative, and accumulated path costs must remain finite.
+The internal Fibonacci heap always expands a node of minimum tentative cost, including
+when a cheaper route decreases an active node's key. Consolidation visits each root once,
+and cascading cuts preserve heap order and amortized `O(1)` insert/decrease-key and
+`O(log V)` extraction. Its degree table grows as needed, is reused across extractions,
+and clears retained node references after consolidation. Equal-cost routes have no guaranteed
+tie order. Returned reachable paths run from target toward seed, excluding the seed; the
+seed path is empty, and an unreachable target returns `[target, seed]`.
+
 Key methods:
 
 - `CalculateShortestPaths(T seed)`

--- a/src/Aardvark.Base/AlgoDat/ShortestPath.cs
+++ b/src/Aardvark.Base/AlgoDat/ShortestPath.cs
@@ -433,7 +433,6 @@ namespace Aardvark.Base
         }
 
         private Node _min;
-        private int _n;
         private Node[] _degreeTable = Array.Empty<Node>();
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -448,7 +447,6 @@ namespace Aardvark.Base
                 if (key < _min.Key)
                     _min = node;
             }
-            _n++;
             return node;
         }
 
@@ -471,7 +469,6 @@ namespace Aardvark.Base
                 min.Isolate();
             }
             _min = next == null || next.Right == next ? next : Consolidate(next);
-            _n--;
             return min.Value;
         }
 

--- a/src/Aardvark.Base/AlgoDat/ShortestPath.cs
+++ b/src/Aardvark.Base/AlgoDat/ShortestPath.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,6 +22,8 @@ namespace Aardvark.Base
     /// <remarks>
     /// Starting a calculation cancels and replaces the current calculation. Path queries are
     /// thread-safe and use the last fully completed result until the replacement completes.
+    /// Costs must be finite and non-negative, with finite accumulated path costs. The frontier
+    /// expands a node of minimum tentative cost, including after decreasing an active node's cost.
     /// </remarks>
     public class ShortestPath<T> : IShortestPath<T>
     {
@@ -276,6 +279,7 @@ namespace Aardvark.Base
 
         /// <summary>
         /// Gets the path from the indexed target toward the seed using one completed result snapshot.
+        /// Reachable paths exclude the seed; the seed path is empty. Unreachable targets return [target, seed].
         /// </summary>
         public List<T> GetMinimalPathByIndex(int endIndex)
         {
@@ -307,315 +311,260 @@ namespace Aardvark.Base
         }
     }
 
+    /// <summary>
+    /// Internal minimum-priority frontier. Insert and decrease-key take O(1) amortized time;
+    /// extraction takes O(log n) amortized time. Keys must not be NaN and decreases must not increase a key.
+    /// </summary>
     class FibonacciHeap<T>
     {
-        public class Node
+        public sealed class Node
         {
-            private readonly T _item;
             private Node _parent;
             private Node _left;
             private Node _right;
             private Node _child;
-            private float _key = 0;
-            private int _degree = 0;
-            private bool _marked = false;
+            private int _degree;
 
             public Node(float key, T item)
             {
-                _key = key;
-                _item = item;
-                _left = this;
-                _right = this;
+                Key = key;
+                Value = item;
+                _left = _right = this;
             }
 
-            public T Value => _item;
-
-            public Node Right
-            {
-                get { return _right; }
-                set
-                {
-                    _right = value;
-                    value._left = this;
-                }
-            }
-
-            public Node Left
-            {
-                get { return _left; }
-                set
-                {
-                    _left = value;
-                    value._right = this;
-                }
-            }
-
-            public Node Parent =>_parent; 
-
-            public Node Child => _child; 
-
-            public void AddChild(Node node)
-            {
-                _degree++;
-                node._parent = this;
-
-                if (_child == null)
-                    _child = node;
-                else
-                    _child.InsertOneBefore(node);
-            }
-
-            public void RemoveChild(Node node)
-            {
-                if (_child != null)
-                {
-                    if (_degree == 1)
-                    {
-                        _child = null;
-                        _degree = 0;
-                        node._parent = null;
-                    }
-                    else
-                    {
-                        if (_child == node)
-                            _child = _child.Left;
-                        node.Isolate();
-                        _degree--;
-                        node._parent = null;
-                    }
-                }
-            }
-
-            public void RemoveAllChildren()
-            {
-                if (_child != null)
-                {
-                    foreach (var child in _child.AllSiblings)
-                        child._parent = null;
-                    _degree = 0;
-                    _child = null;
-                }
-            }
-
-            public void InsertOneBefore(Node node)
-            {
-                var right = Right;
-                Right = node;
-                right.Left = node;
-            }
-
-            public void InsertGroupBefore(Node node)
-            {
-                var start = node;
-                var end = start.Left;
-
-                var right = Right;
-                Right = start;
-                right.Left = end;
-            }
-
-            public void Isolate()
-            {
-                var left = Left;
-                var right = Right;
-                left.Right = right;
-                Left = this;
-            }
-
-            public float Key
-            {
-                get { return _key; }
-                set { _key = value; }
-            }
-
+            public T Value { get; }
+            public Node Parent => _parent;
+            public Node Left => _left;
+            public Node Right => _right;
+            public Node Child => _child;
+            public float Key { get; set; }
             public int Degree => _degree;
+            public bool Marked { get; set; }
 
-            public bool Marked
+            // Move directly between rings, avoiding redundant self-links before insertion.
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void AddChild(Node node, int degree)
             {
-                get { return _marked; }
-                set { _marked = value; }
-            }
-
-            public IEnumerable<Node> GetAllChildren()
-            {
-                if (_child == null)
-                    return Enumerable.Empty<Node>();
-                return _child.AllSiblings;
-            }
-
-            public IEnumerable<Node> AllSiblings
-            {
-                get
+                node.Unlink();
+                _degree = degree;
+                node._parent = this; // Both incoming roots are already unmarked.
+                if (degree == 1)
                 {
-                    var node = this;
+                    node._left = node._right = node;
+                    _child = node;
+                }
+                else
+                    _child.InsertAfter(node);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void CutChild(Node node, Node root)
+            {
+                if (_child == node)
+                    _child = _degree == 1 ? null : node._right;
+                _degree--;
+                node.Unlink();
+                node._parent = null;
+                node.Marked = false;
+                root.InsertBefore(node);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public Node RemoveAllChildren()
+            {
+                var first = _child;
+                if (first != null)
+                {
+                    var child = first;
                     do
                     {
-                        yield return node;
-                        node = node.Right;
-                    } while (node != this);
+                        child._parent = null;
+                        child.Marked = false;
+                        child = child._right;
+                    } while (child != first);
+                    _child = null;
+                    _degree = 0;
                 }
+                return first;
             }
 
-            public bool HasNoSiblings() => _left == this;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void InsertAfter(Node node)
+            {
+                node._left = this;
+                node._right = _right;
+                _right._left = node;
+                _right = node;
+            }
 
-            public bool HasMaxOneSibling() => _left._left == this;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void InsertBefore(Node node)
+            {
+                node._right = this;
+                node._left = _left;
+                _left._right = node;
+                _left = node;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void ReplaceWithRing(Node first)
+            {
+                var last = first._left;
+                first._left = _left;
+                _left._right = first;
+                last._right = _right;
+                _right._left = last;
+                _left = _right = this;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private void Unlink()
+            {
+                _left._right = _right;
+                _right._left = _left;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void Isolate()
+            {
+                Unlink();
+                _left = _right = this;
+            }
         }
 
         private Node _min;
-        private int _n = 0;
+        private int _n;
+        private Node[] _degreeTable = Array.Empty<Node>();
 
-        public void Insert(Node node)
-        {
-            if (_min == null)
-            {
-                _min = node;
-            }
-            else
-            {
-                _min.InsertOneBefore(node);
-                if (node.Key < _min.Key)
-                    _min = node;
-            }
-            _n++;
-        }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Node Insert(float key, T item)
         {
             var node = new Node(key, item);
-            Insert(node);
+            if (_min == null)
+                _min = node;
+            else
+            {
+                _min.InsertAfter(node);
+                if (key < _min.Key)
+                    _min = node;
+            }
+            _n++;
             return node;
         }
 
-        public T GetMin() => _min.Value;
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public T DeleteMin()
         {
             var min = _min;
-            if (_min != null)
+            var children = min.RemoveAllChildren();
+            Node next;
+            if (min.Right == min)
+                next = children;
+            else if (children != null)
             {
-                if (_min.HasNoSiblings() && _min.Degree == 0)
-                {
-                    _min = null;
-                }
-                else
-                {
-                    if (_min.Degree > 0)
-                    {
-                        var child = _min.Child;
-                        _min.RemoveAllChildren();
-
-                        if (!_min.HasNoSiblings())
-                        {
-                            _min.InsertGroupBefore(child);
-                            _min.Isolate();
-                        }
-                        _min = child;
-                    }
-                    else
-                    {
-                        var left = _min.Left;
-                        _min.Isolate();
-                        _min = left;
-                    }
-                    Consolidate();
-                }
-                _n--;
+                next = children;
+                min.ReplaceWithRing(children);
             }
+            else
+            {
+                next = min.Right;
+                min.Isolate();
+            }
+            _min = next == null || next.Right == next ? next : Consolidate(next);
+            _n--;
             return min.Value;
         }
 
-        /*private static Node FindMinSibling(Node node)
-        {
-            var minNode = node;
-            foreach (var n in node.AllSiblings)
-            {
-                if (n.Key < minNode.Key)
-                {
-                    minNode = n;
-                }
-            }
-            return minNode;
-        }*/
-
-        public void Delete(Node node)
-        {
-            DecreaseKey(node, int.MinValue);
-            DeleteMin();
-        }
-
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void DecreaseKey(Node node, float newKey)
         {
             node.Key = newKey;
-
-            if (node.Parent == null)
+            var parent = node.Parent;
+            if (parent != null && newKey < parent.Key)
             {
-                if (newKey < _min.Key)
-                    _min = node;
-            }
-            else if (node.Key < node.Parent.Key)
-            {
-                var parent = node.Parent;
-                parent.RemoveChild(node);
-                _min.InsertOneBefore(node);
-                if (!parent.Marked)
-                    parent.Marked = true;
-                else
+                parent.CutChild(node, _min);
+                while (parent.Parent != null)
                 {
-                    while (parent.Parent != null && parent.Marked)
+                    if (!parent.Marked)
                     {
-                        var pparent = parent.Parent;
-                        pparent.RemoveChild(parent);
-                        _min.InsertOneBefore(parent);
-                        parent.Marked = false;
-                        parent = pparent;
+                        // A non-root may lose one child; losing another cuts it as well.
+                        parent.Marked = true;
+                        break;
                     }
+                    var ancestor = parent.Parent;
+                    ancestor.CutChild(parent, _min);
+                    parent = ancestor;
                 }
             }
+            // A decreased child can become the global minimum just like a decreased root.
+            if (newKey < _min.Key)
+                _min = node;
         }
 
         public bool IsEmpty() => _min == null;
 
-        private void Consolidate()
+        private Node Consolidate(Node current)
         {
-            if (_min == null)
-                return;
+            var last = current.Left;
+            // A two-root frontier can be consolidated without scratch storage.
+            if (current.Right == last)
+            {
+                if (last.Key < current.Key)
+                    Fun.Swap(ref current, ref last);
+                if (current.Degree == last.Degree)
+                    current.AddChild(last, current.Degree + 1);
+                return current;
+            }
 
-            var lookup = new Node[2 * (int)(_n.Log() + 1)];
-            var last = _min;
-            var current = _min;
-            var newMin = _min;
-            bool stop = false;
+            var table = _degreeTable;
+            Node root;
+            bool isLast;
             do
             {
+                // Only previously processed roots enter the table. Until the final root,
+                // neither last nor next can be linked away. Test the boundary before linking.
+                isLast = current == last;
                 var next = current.Right;
-                while (lookup[current.Degree] != null)
+                root = current;
+                int degree = root.Degree;
+                while (degree < table.Length && table[degree] != null)
                 {
-                    var right = current.Right;
-                    var first = current;
-                    var second = lookup[current.Degree];
-
-                    if (second == right && right.Right != first)
-                        right = right.Right;
-
-                    lookup[current.Degree] = null;
-
-                    if (second.Key < first.Key)
-                        Fun.Swap(ref first, ref second);
-
-                    second.Isolate();
-                    first.AddChild(second);
-
-                    current = first;
-                    if (newMin.Key > first.Key || second == newMin)
-                        newMin = first;
-
-                    if (second == last)
-                        stop = true;
+                    var other = table[degree];
+                    table[degree] = null;
+                    if (other.Key < root.Key)
+                        Fun.Swap(ref root, ref other);
+                    degree++;
+                    root.AddChild(other, degree);
                 }
-                lookup[current.Degree] = current;
+
+                // Grow from actual degrees, not a rounded logarithmic estimate of the node count.
+                if (degree >= table.Length)
+                    table = GrowDegreeTable(degree);
+                table[degree] = root;
                 current = next;
-            } while (current != last && !stop);
-            _min = newMin;
+            } while (!isLast);
+
+            // The final winner is still a root. Inspect every surviving root, including
+            // those never linked, without retaining a minimum that may have become a child.
+            var minimum = root;
+            float minimumKey = root.Key;
+            table[root.Degree] = null;
+            for (var node = root.Right; node != root; node = node.Right)
+            {
+                table[node.Degree] = null; // Consumed slots were cleared when linking; clear the survivors too.
+                if (node.Key < minimumKey)
+                {
+                    minimum = node;
+                    minimumKey = node.Key;
+                }
+            }
+            return minimum;
+        }
+
+        private Node[] GrowDegreeTable(int degree)
+        {
+            Array.Resize(ref _degreeTable, Math.Max(degree + 1, Math.Max(8, _degreeTable.Length * 2)));
+            return _degreeTable;
         }
     }
 }

--- a/src/Aardvark.Base/AlgoDat/ShortestPath.cs
+++ b/src/Aardvark.Base/AlgoDat/ShortestPath.cs
@@ -313,58 +313,84 @@ namespace Aardvark.Base
 
     /// <summary>
     /// Internal minimum-priority frontier. Insert and decrease-key take O(1) amortized time;
-    /// extraction takes O(log n) amortized time. Keys must not be NaN and decreases must not increase a key.
+    /// extraction takes O(log n) amortized time. Keys must be finite and decreases must not increase a key.
     /// </summary>
     class FibonacciHeap<T>
     {
         public sealed class Node
         {
-            private Node _parent;
-            private Node _left;
-            private Node _right;
-            private Node _child;
+            // Intrusive links use registry indices so consolidation does not pay a GC
+            // write barrier for every sibling and parent update.
+            private FibonacciHeap<T> _heap;
+            internal readonly int _index;
+            private int _parent = -1;
+            private int _left;
+            private int _right;
+            private int _child = -1;
             private int _degree;
+            private bool _released;
 
-            public Node(float key, T item)
+            internal Node(FibonacciHeap<T> heap, int index, float key, T item)
             {
+                _heap = heap;
+                _index = index;
                 Key = key;
                 Value = item;
-                _left = _right = this;
+                _left = _right = index;
             }
 
             public T Value { get; }
-            public Node Parent => _parent;
-            public Node Left => _left;
-            public Node Right => _right;
-            public Node Child => _child;
+            public Node Parent => _parent < 0 ? null : _heap._nodes[_parent];
+            public Node Left => _released ? this : _heap._nodes[_left];
+            public Node Right => _released ? this : _heap._nodes[_right];
+            public Node Child => _child < 0 ? null : _heap._nodes[_child];
             public float Key { get; set; }
             public int Degree => _degree;
             public bool Marked { get; set; }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static Node CreateAfter(Node anchor, float key, T item)
+            {
+                var heap = anchor._heap;
+                var node = heap.CreateNode(key, item);
+                int right = anchor._right;
+                node._left = anchor._index;
+                node._right = right;
+                heap._nodes[right]._left = node._index;
+                anchor._right = node._index;
+                return node;
+            }
 
             // Move directly between rings, avoiding redundant self-links before insertion.
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void AddChild(Node node, int degree)
             {
                 node.Unlink();
+                AddDetachedChild(node, degree);
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void AddDetachedChild(Node node, int degree)
+            {
                 _degree = degree;
-                node._parent = this; // Both incoming roots are already unmarked.
+                node._parent = _index;
                 if (degree == 1)
                 {
-                    node._left = node._right = node;
-                    _child = node;
+                    node._left = node._right = node._index;
+                    _child = node._index;
                 }
                 else
-                    _child.InsertAfter(node);
+                    _heap._nodes[_child].InsertAfter(node);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void CutChild(Node node, Node root)
             {
-                if (_child == node)
-                    _child = _degree == 1 ? null : node._right;
+                if (_child == node._index)
+                    _child = _degree == 1 ? -1 : node._right;
                 _degree--;
                 node.Unlink();
-                node._parent = null;
+                node._parent = -1;
                 node.Marked = false;
                 root.InsertBefore(node);
             }
@@ -372,82 +398,141 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public Node RemoveAllChildren()
             {
-                var first = _child;
-                if (first != null)
+                int first = _child;
+                if (first >= 0)
                 {
-                    var child = first;
-                    do
-                    {
-                        child._parent = null;
-                        child.Marked = false;
-                        child = child._right;
-                    } while (child != first);
-                    _child = null;
+                    _child = -1;
                     _degree = 0;
                 }
-                return first;
+                return first < 0 ? null : _heap._nodes[first];
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void MakeRoot()
+            {
+                if (_parent >= 0)
+                {
+                    _parent = -1;
+                    Marked = false;
+                }
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void InsertAfter(Node node)
             {
-                node._left = this;
+                node._left = _index;
                 node._right = _right;
-                _right._left = node;
-                _right = node;
+                _heap._nodes[_right]._left = node._index;
+                _right = node._index;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void InsertBefore(Node node)
             {
-                node._right = this;
+                node._right = _index;
                 node._left = _left;
-                _left._right = node;
-                _left = node;
+                _heap._nodes[_left]._right = node._index;
+                _left = node._index;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public void LinkNext(Node node)
+            {
+                _right = node._index;
+                node._left = _index;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void ReplaceWithRing(Node first)
             {
-                var last = first._left;
+                int last = first._left;
                 first._left = _left;
-                _left._right = first;
-                last._right = _right;
-                _right._left = last;
-                _left = _right = this;
+                _heap._nodes[_left]._right = first._index;
+                _heap._nodes[last]._right = _right;
+                _heap._nodes[_right]._left = last;
+                _left = _right = _index;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void Unlink()
             {
-                _left._right = _right;
-                _right._left = _left;
+                _heap._nodes[_left]._right = _right;
+                _heap._nodes[_right]._left = _left;
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public void Isolate()
             {
                 Unlink();
-                _left = _right = this;
+                _left = _right = _index;
+            }
+
+            public void Release()
+            {
+                _parent = _child = -1;
+                _left = _right = _index;
+                _degree = 0;
+                Marked = false;
+                _released = true;
+                _heap = null;
             }
         }
 
+        private Node[] _nodes = Array.Empty<Node>();
+        private int[] _freeIndices = Array.Empty<int>();
+        private int _nextIndex;
+        private int _freeCount;
         private Node _min;
         private Node[] _degreeTable = Array.Empty<Node>();
+        private bool _allRootsAreLeaves = true;
+        private bool _mayHaveMarkedNodes;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public Node Insert(float key, T item)
         {
-            var node = new Node(key, item);
-            if (_min == null)
+            Node node;
+            var min = _min;
+            if (min == null)
+            {
+                node = CreateNode(key, item);
                 _min = node;
+            }
             else
             {
-                _min.InsertAfter(node);
-                if (key < _min.Key)
+                node = Node.CreateAfter(min, key, item);
+                if (key < min.Key)
                     _min = node;
             }
             return node;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private Node CreateNode(float key, T item)
+        {
+            int index;
+            if (_freeCount > 0)
+                index = _freeIndices[--_freeCount];
+            else
+            {
+                index = _nextIndex++;
+                if (index == _nodes.Length)
+                    Array.Resize(ref _nodes, Math.Max(8, index * 2));
+            }
+
+            var node = new Node(this, index, key, item);
+            _nodes[index] = node;
+            return node;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private void ReleaseNode(Node node)
+        {
+            int index = node._index;
+            _nodes[index] = null;
+            if (_freeCount == _freeIndices.Length)
+                Array.Resize(ref _freeIndices, Math.Max(8, _freeCount * 2));
+            _freeIndices[_freeCount++] = index;
+            node.Release();
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -455,6 +540,8 @@ namespace Aardvark.Base
         {
             var min = _min;
             var children = min.RemoveAllChildren();
+            if (_mayHaveMarkedNodes && children != null)
+                ClearMarks(children);
             Node next;
             if (min.Right == min)
                 next = children;
@@ -468,8 +555,33 @@ namespace Aardvark.Base
                 next = min.Right;
                 min.Isolate();
             }
-            _min = next == null || next.Right == next ? next : Consolidate(next);
-            return min.Value;
+            if (next == null)
+            {
+                _min = null;
+                _allRootsAreLeaves = true;
+                _mayHaveMarkedNodes = false;
+            }
+            else if (next.Right == next)
+            {
+                next.MakeRoot();
+                _min = next;
+            }
+            else
+                _min = Consolidate(next);
+            var value = min.Value;
+            ReleaseNode(min);
+            return value;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void ClearMarks(Node first)
+        {
+            var node = first;
+            do
+            {
+                node.Marked = false;
+                node = node.Right;
+            } while (node != first);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -486,6 +598,7 @@ namespace Aardvark.Base
                     {
                         // A non-root may lose one child; losing another cuts it as well.
                         parent.Marked = true;
+                        _mayHaveMarkedNodes = true;
                         break;
                     }
                     var ancestor = parent.Parent;
@@ -505,15 +618,18 @@ namespace Aardvark.Base
             var last = current.Left;
             // A two-root frontier can be consolidated without scratch storage.
             if (current.Right == last)
+                return ConsolidateTwo(current, last);
+
+            if (_allRootsAreLeaves)
             {
-                if (last.Key < current.Key)
-                    Fun.Swap(ref current, ref last);
-                if (current.Degree == last.Degree)
-                    current.AddChild(last, current.Degree + 1);
-                return current;
+                _allRootsAreLeaves = false;
+                return ConsolidateInitial(current, last);
             }
 
             var table = _degreeTable;
+            if (table.Length == 0)
+                table = GrowDegreeTable(0);
+
             Node root;
             bool isLast;
             do
@@ -524,31 +640,38 @@ namespace Aardvark.Base
                 var next = current.Right;
                 root = current;
                 int degree = root.Degree;
-                while (degree < table.Length && table[degree] != null)
+                while (table[degree] != null)
                 {
                     var other = table[degree];
                     table[degree] = null;
-                    if (other.Key < root.Key)
-                        Fun.Swap(ref root, ref other);
+                    float otherKey = other.Key;
+                    if (otherKey < root.Key)
+                    {
+                        var swap = root;
+                        root = other;
+                        other = swap;
+                    }
                     degree++;
                     root.AddChild(other, degree);
                 }
 
                 // Grow from actual degrees, not a rounded logarithmic estimate of the node count.
-                if (degree >= table.Length)
+                if (degree >= table.Length - 1)
                     table = GrowDegreeTable(degree);
                 table[degree] = root;
                 current = next;
             } while (!isLast);
 
-            // The final winner is still a root. Inspect every surviving root, including
-            // those never linked, without retaining a minimum that may have become a child.
+            // Inspect every surviving root, including those never linked, without
+            // retaining a minimum that may have become a child.
             var minimum = root;
             float minimumKey = root.Key;
+            root.MakeRoot();
             table[root.Degree] = null;
             for (var node = root.Right; node != root; node = node.Right)
             {
-                table[node.Degree] = null; // Consumed slots were cleared when linking; clear the survivors too.
+                node.MakeRoot();
+                table[node.Degree] = null;
                 if (node.Key < minimumKey)
                 {
                     minimum = node;
@@ -558,9 +681,95 @@ namespace Aardvark.Base
             return minimum;
         }
 
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private Node ConsolidateTwo(Node current, Node last)
+        {
+            _allRootsAreLeaves = false;
+            if (last.Key < current.Key)
+            {
+                var swap = current;
+                current = last;
+                last = swap;
+            }
+            if (current.Degree == last.Degree)
+            {
+                int degree = current.Degree + 1;
+                if (degree >= _degreeTable.Length - 1)
+                    GrowDegreeTable(degree);
+                current.AddChild(last, degree);
+                current.MakeRoot();
+            }
+            else
+            {
+                current.MakeRoot();
+                last.MakeRoot();
+            }
+            return current;
+        }
+
+        private Node ConsolidateInitial(Node current, Node last)
+        {
+            var table = _degreeTable;
+            if (table.Length == 0)
+                table = GrowDegreeTable(0);
+
+            Node root;
+            bool isLast;
+            do
+            {
+                isLast = current == last;
+                var next = current.Right;
+                root = current;
+                int degree = 0;
+                while (table[degree] != null)
+                {
+                    var other = table[degree];
+                    table[degree] = null;
+                    float otherKey = other.Key;
+                    if (otherKey < root.Key)
+                    {
+                        var swap = root;
+                        root = other;
+                        other = swap;
+                    }
+                    degree++;
+                    root.AddDetachedChild(other, degree);
+                }
+
+                if (degree >= table.Length - 1)
+                    table = GrowDegreeTable(degree);
+                table[degree] = root;
+                current = next;
+            } while (!isLast);
+
+            Node first = null;
+            Node previous = null;
+            Node minimum = null;
+            float minimumKey = float.PositiveInfinity;
+            for (int degree = table.Length - 1; degree >= 0; degree--)
+            {
+                root = table[degree];
+                if (root == null)
+                    continue;
+                table[degree] = null;
+                if (first == null)
+                    first = root;
+                else
+                    previous.LinkNext(root);
+                previous = root;
+                if (root.Key < minimumKey)
+                {
+                    minimum = root;
+                    minimumKey = root.Key;
+                }
+            }
+            previous.LinkNext(first);
+            return minimum;
+        }
+
         private Node[] GrowDegreeTable(int degree)
         {
-            Array.Resize(ref _degreeTable, Math.Max(degree + 1, Math.Max(8, _degreeTable.Length * 2)));
+            Array.Resize(ref _degreeTable, Math.Max(degree + 2, Math.Max(8, _degreeTable.Length * 2)));
             return _degreeTable;
         }
     }

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.cs
@@ -1,0 +1,139 @@
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Aardvark.Base.Benchmarks
+{
+    /// <summary>
+    /// Run with: dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- --filter '*ShortestPathBenchmark*'
+    /// Heap workloads include insertion and draining; inputs, handle storage and delegate binding are setup-only.
+    /// Graph workloads invoke the unchanged calculation body synchronously, including run-owned allocations,
+    /// but excluding graph construction, reflection, thread-pool scheduling and asynchronous waiting.
+    /// </summary>
+    [MemoryDiagnoser]
+    public class ShortestPathBenchmark
+    {
+        [Params(32, 4096)]
+        public int Count { get; set; }
+
+        private object _heap;
+        private object[] _nodes;
+        private float[] _keys;
+        private Func<object, float, int, object> _insert;
+        private Func<object, int> _extract;
+        private Action<object, object, float> _decrease;
+        private Action<ShortestPath<int>> _calculate;
+        private ShortestPath<int> _sparse;
+        private ShortestPath<int> _grid;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            Report.RootTarget = Report.NoTarget;
+            BindHeap();
+            _nodes = new object[Count];
+            var random = new Random(731);
+            _keys = Enumerable.Range(0, Count).Select(_ => (float)random.Next(1, 100000)).ToArray();
+            _sparse = CreateGraph(false);
+            _grid = CreateGraph(true);
+            BindCalculation();
+        }
+
+        [Benchmark]
+        public long InsertDrain()
+        {
+            for (int i = 0; i < Count; i++) _insert(_heap, _keys[i], i);
+            long checksum = 0;
+            for (int i = 0; i < Count; i++) checksum += _extract(_heap);
+            return checksum;
+        }
+
+        [Benchmark]
+        public long InsertDecreaseDrain()
+        {
+            _insert(_heap, -1, -1);
+            for (int i = 0; i < Count; i++) _nodes[i] = _insert(_heap, _keys[i], i);
+            _extract(_heap); // Consolidate so decreases exercise child cuts, not just root updates.
+            for (int i = 0; i < Count; i++) _decrease(_heap, _nodes[i], -2 - i);
+            long checksum = 0;
+            for (int i = 0; i < Count; i++) checksum += _extract(_heap);
+            return checksum;
+        }
+
+        [Benchmark]
+        public void SparseGraph() => _calculate(_sparse);
+
+        [Benchmark]
+        public void GridGraph() => _calculate(_grid);
+
+        private void BindHeap()
+        {
+            var heapType = typeof(ShortestPath<int>).Assembly.GetType("Aardvark.Base.FibonacciHeap`1", true)
+                .MakeGenericType(typeof(int));
+            _heap = Activator.CreateInstance(heapType, true);
+            var heap = Expression.Parameter(typeof(object), "heap");
+            var key = Expression.Parameter(typeof(float), "key");
+            var value = Expression.Parameter(typeof(int), "value");
+            var node = Expression.Parameter(typeof(object), "node");
+            var insert = heapType.GetMethod("Insert", new[] { typeof(float), typeof(int) });
+            var decrease = heapType.GetMethod("DecreaseKey");
+            _insert = Expression.Lambda<Func<object, float, int, object>>(
+                Expression.Convert(Expression.Call(Expression.Convert(heap, heapType), insert, key, value), typeof(object)),
+                heap, key, value).Compile();
+            _extract = Expression.Lambda<Func<object, int>>(
+                Expression.Call(Expression.Convert(heap, heapType), heapType.GetMethod("DeleteMin")), heap).Compile();
+            _decrease = Expression.Lambda<Action<object, object, float>>(
+                Expression.Call(Expression.Convert(heap, heapType), decrease,
+                    Expression.Convert(node, decrease.GetParameters()[0].ParameterType), key), heap, node, key).Compile();
+        }
+
+        private void BindCalculation()
+        {
+            const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Instance;
+            var type = typeof(ShortestPath<int>);
+            var currentRun = type.GetField("m_currentRun", flags);
+            var runType = currentRun.FieldType;
+            var path = Expression.Parameter(type, "path");
+            var run = Expression.Variable(runType, "run");
+            _calculate = Expression.Lambda<Action<ShortestPath<int>>>(Expression.Block(new[] { run },
+                Expression.Assign(run, Expression.New(runType.GetConstructor(new[] { typeof(int), typeof(int) }),
+                    Expression.Constant(0), Expression.Constant(Count))),
+                Expression.Assign(Expression.Field(path, currentRun), run),
+                Expression.Call(path, type.GetMethod("Calculate", flags), run)), path).Compile();
+        }
+
+        private ShortestPath<int> CreateGraph(bool grid)
+        {
+            var random = new Random(137);
+            var neighbors = Enumerable.Range(0, Count).Select(_ => new List<int>()).ToArray();
+            int width = (int)Math.Sqrt(Count);
+            for (int i = 0; i < Count; i++)
+            {
+                if (i > 0 && (!grid || i % width != 0)) AddEdge(i - 1, i);
+                if (grid)
+                {
+                    if (i >= width) AddEdge(i - width, i);
+                }
+                else
+                {
+                    for (int j = 0; j < 5; j++)
+                    {
+                        int other = random.Next(Count);
+                        if (other != i) AddEdge(i, other);
+                    }
+                }
+            }
+            return new ShortestPath<int>(Enumerable.Range(0, Count).ToArray(), neighbors,
+                (a, b) => 1 + ((Math.Min(a, b) * 31 + Math.Max(a, b) * 17) % 97));
+
+            void AddEdge(int a, int b)
+            {
+                neighbors[a].Add(b);
+                neighbors[b].Add(a);
+            }
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
@@ -38,18 +38,19 @@ allocation count, but eliminate repeated consolidation scratch allocations.
 
 | Workload | Count | Baseline (µs) | Revised (µs) | Throughput change | Baseline bytes | Revised bytes |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| Insert/drain | 32 | 3.633 | 2.789 | +30.2% | 5,368 | 2,048 |
-| Insert/decrease/drain | 32 | 3.459 | 3.493 | -1.0% | 5,328 | 2,112 |
-| Sparse graph | 32 | 6.578 | 5.635 | +16.7% | 8,072 | 4,952 |
-| Grid graph | 32 | 4.588 | 3.537 | +29.7% | 5,864 | 3,336 |
-| Insert/drain | 4096 | 1296.112 | 1352.092 | **-4.1%** | 1,054,440 | 262,144 |
-| Insert/decrease/drain | 4096 | 747.560 | 796.808 | **-6.2%** | 1,003,504 | 262,208 |
-| Sparse graph | 4096 | 2215.660 | 2109.934 | +5.0% | 1,291,648 | 515,336 |
-| Grid graph | 4096 | 1070.752 | 883.695 | +21.2% | 914,208 | 304,168 |
+| Insert/drain | 32 | 3.689 | 2.769 | +33.2% | 5,368 | 2,048 |
+| Insert/decrease/drain | 32 | 3.595 | 3.617 | -0.6% | 5,328 | 2,112 |
+| Sparse graph | 32 | 6.501 | 5.711 | +13.8% | 8,072 | 4,944 |
+| Grid graph | 32 | 4.611 | 3.546 | +30.0% | 5,864 | 3,328 |
+| Insert/drain | 4096 | 1303.250 | 1352.298 | **-3.6%** | 1,054,440 | 262,144 |
+| Insert/decrease/drain | 4096 | 772.124 | 783.189 | -1.4% | 1,003,504 | 262,208 |
+| Sparse graph | 4096 | 2188.635 | 2075.169 | +5.5% | 1,291,648 | 515,328 |
+| Grid graph | 4096 | 1072.893 | 871.695 | +23.1% | 914,208 | 304,160 |
 
-Allocation reductions range from 38.7% to 75.1%. Small-heap decrease/drain is within
-measurement variation, but the larger heap-only regressions repeat across both
-passes. **The no-throughput-regression acceptance gate is not met.**
+Allocation reductions range from 38.7% to 75.1%. Removing obsolete heap-size
+bookkeeping brings decrease/drain much closer to parity, but the larger
+insertion/drain regression repeats across both passes.
+**The no-throughput-regression acceptance gate is not met.**
 
 An additional alternating, warmed comparison of the same fixture methods in one
 process found neutral or improved large-heap results. That does not override the

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
@@ -1,0 +1,63 @@
+# Shortest-path priority benchmarks
+
+Tracking: [#131](https://github.com/aardvark-platform/aardvark.base/issues/131).
+
+Run the retained fixture without changing the benchmark dispatcher:
+
+```sh
+dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
+  --filter '*ShortestPathBenchmark*' --inProcess \
+  --warmupCount 8 --iterationCount 30 --iterationTime 300
+```
+
+## Workloads and measurement boundaries
+
+- `InsertDrain`: insert deterministic random keys, then extract every item.
+- `InsertDecreaseDrain`: insert a sentinel and random keys, extract the sentinel to
+  consolidate, decrease all remaining keys, then drain. Insertion and extraction
+  are intentionally included; this is not an isolated decrease-key latency test.
+- `SparseGraph` and `GridGraph`: calculate paths on fixed non-negative weighted
+  graphs. These invoke the existing calculation body synchronously, including
+  allocation of run state and result publication, but excluding scheduling and
+  waiting. They measure calculation work, not asynchronous API latency.
+
+Reflection and delegate compilation, input generation, graph construction, and
+handle-array allocation occur only in global setup. The heap instance is reused
+between invocations, so retained degree storage is warmed. Node allocations remain
+inside the measured heap workloads. No reflection occurs in the timed methods.
+
+## Baseline comparison
+
+Baseline: unchanged library at `c79192f8`, with the identical benchmark fixture.
+Both versions used Release, .NET 8.0.26, the same processor affinity, eight warmup
+iterations and thirty 300-ms measurement iterations. Each version was measured
+in two passes, with the order reversed for the second pair. Times below average
+those two BenchmarkDotNet means. Throughput change is `baseline time / new time - 1`.
+Allocated bytes are per complete invocation; heap workloads retain the same node
+allocation count, but eliminate repeated consolidation scratch allocations.
+
+| Workload | Count | Baseline (µs) | Revised (µs) | Throughput change | Baseline bytes | Revised bytes |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Insert/drain | 32 | 3.633 | 2.789 | +30.2% | 5,368 | 2,048 |
+| Insert/decrease/drain | 32 | 3.459 | 3.493 | -1.0% | 5,328 | 2,112 |
+| Sparse graph | 32 | 6.578 | 5.635 | +16.7% | 8,072 | 4,952 |
+| Grid graph | 32 | 4.588 | 3.537 | +29.7% | 5,864 | 3,336 |
+| Insert/drain | 4096 | 1296.112 | 1352.092 | **-4.1%** | 1,054,440 | 262,144 |
+| Insert/decrease/drain | 4096 | 747.560 | 796.808 | **-6.2%** | 1,003,504 | 262,208 |
+| Sparse graph | 4096 | 2215.660 | 2109.934 | +5.0% | 1,291,648 | 515,336 |
+| Grid graph | 4096 | 1070.752 | 883.695 | +21.2% | 914,208 | 304,168 |
+
+Allocation reductions range from 38.7% to 75.1%. Small-heap decrease/drain is within
+measurement variation, but the larger heap-only regressions repeat across both
+passes. **The no-throughput-regression acceptance gate is not met.**
+
+An additional alternating, warmed comparison of the same fixture methods in one
+process found neutral or improved large-heap results. That does not override the
+regressions in the isolated BenchmarkDotNet workloads above; sharing GC pressure
+between baseline and revised workloads changes the measurement environment.
+
+The baseline is incorrect: these are matched inputs, not equivalent priority
+results. Its early-stop consolidation can leave most roots unlinked, doing fewer
+links and cuts. The correctness regressions and reference-model tests are separate
+from timing; a checksum in the benchmark only consumes results and is not an
+ordering oracle. Further optimization must preserve those correctness checks.

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md
@@ -23,8 +23,10 @@ dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
 
 Reflection and delegate compilation, input generation, graph construction, and
 handle-array allocation occur only in global setup. The heap instance is reused
-between invocations, so retained degree storage is warmed. Node allocations remain
-inside the measured heap workloads. No reflection occurs in the timed methods.
+between heap-workload invocations, so retained degree, node-registry, and free-index
+storage is warmed. Node allocations remain inside the measured heap workloads.
+Graph workloads create their heap inside the calculation and include all of its
+storage. No reflection occurs in the timed methods.
 
 ## Baseline comparison
 
@@ -38,24 +40,18 @@ allocation count, but eliminate repeated consolidation scratch allocations.
 
 | Workload | Count | Baseline (µs) | Revised (µs) | Throughput change | Baseline bytes | Revised bytes |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| Insert/drain | 32 | 3.689 | 2.769 | +33.2% | 5,368 | 2,048 |
-| Insert/decrease/drain | 32 | 3.595 | 3.617 | -0.6% | 5,328 | 2,112 |
-| Sparse graph | 32 | 6.501 | 5.711 | +13.8% | 8,072 | 4,944 |
-| Grid graph | 32 | 4.611 | 3.546 | +30.0% | 5,864 | 3,328 |
-| Insert/drain | 4096 | 1303.250 | 1352.298 | **-3.6%** | 1,054,440 | 262,144 |
-| Insert/decrease/drain | 4096 | 772.124 | 783.189 | -1.4% | 1,003,504 | 262,208 |
-| Sparse graph | 4096 | 2188.635 | 2075.169 | +5.5% | 1,291,648 | 515,328 |
-| Grid graph | 4096 | 1072.893 | 871.695 | +23.1% | 914,208 | 304,160 |
+| Insert/drain | 32 | 3.724 | 1.830 | +103.5% | 5,368 | 2,048 |
+| Insert/decrease/drain | 32 | 3.582 | 2.350 | +52.4% | 5,328 | 2,112 |
+| Sparse graph | 32 | 6.666 | 5.374 | +24.0% | 8,072 | 5,792 |
+| Grid graph | 32 | 4.755 | 3.155 | +50.7% | 5,864 | 3,504 |
+| Insert/drain | 4096 | 1312.584 | 1068.664 | +22.8% | 1,054,440 | 262,144 |
+| Insert/decrease/drain | 4096 | 769.705 | 660.887 | +16.5% | 1,003,504 | 262,208 |
+| Sparse graph | 4096 | 2277.810 | 2059.592 | +10.6% | 1,291,648 | 614,072 |
+| Grid graph | 4096 | 1107.959 | 821.209 | +34.9% | 914,208 | 307,412 |
 
-Allocation reductions range from 38.7% to 75.1%. Removing obsolete heap-size
-bookkeeping brings decrease/drain much closer to parity, but the larger
-insertion/drain regression repeats across both passes.
-**The no-throughput-regression acceptance gate is not met.**
-
-An additional alternating, warmed comparison of the same fixture methods in one
-process found neutral or improved large-heap results. That does not override the
-regressions in the isolated BenchmarkDotNet workloads above; sharing GC pressure
-between baseline and revised workloads changes the measurement environment.
+Allocation reductions range from 28.2% to 75.1%. Index-backed intrusive links
+avoid GC write barriers during ring mutation while the registry retains only active
+nodes. All matched workloads improve, so the throughput and allocation gates pass.
 
 The baseline is incorrect: these are matched inputs, not equivalent priority
 results. Its early-stop consolidation can leave most roots unlinked, doing fewer

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
@@ -33,9 +33,13 @@ namespace Aardvark.Tests
             public void Validate(Dictionary<int, (object Node, float Key)> expected)
             {
                 Assert.That((Array)Field("_degreeTable"), Has.All.Null, "Scratch storage must not retain nodes");
+                var registry = (Array)Field("_nodes");
+                Assert.That((int)Field("_freeCount") + expected.Count, Is.EqualTo((int)Field("_nextIndex")),
+                    "Every allocated registry slot must be active or reusable");
                 if (expected.Count == 0)
                 {
                     Assert.That(Min, Is.Null);
+                    Assert.That(registry, Has.All.Null, "Registry must release extracted nodes");
                     return;
                 }
 
@@ -78,6 +82,16 @@ namespace Aardvark.Tests
                         Assert.That(Get<int>(parent, "Degree"), Is.EqualTo(degree), "Child count");
                 }
                 Assert.That(seen.Count, Is.EqualTo(expected.Count), "Reachable node count");
+
+                int retained = 0;
+                foreach (object node in registry)
+                {
+                    if (node == null)
+                        continue;
+                    retained++;
+                    Assert.That(seen.Contains(node), Is.True, "Registry retained a non-active node");
+                }
+                Assert.That(retained, Is.EqualTo(expected.Count), "Registry node count");
             }
         }
 
@@ -211,6 +225,41 @@ namespace Aardvark.Tests
                 expected[Heap.Get<int>(node, "Value")] = (node, key);
                 heap.Validate(expected);
             }
+        }
+
+        [Test]
+        public void ReleasedHandlesStayIsolatedWhenRegistrySlotsAreReused()
+        {
+            var heap = new Heap();
+            var expected = new Dictionary<int, (object Node, float Key)>
+            {
+                [0] = (heap.Insert(0, 0), 0),
+                [1] = (heap.Insert(1, 1), 1)
+            };
+            var extracted = expected[0].Node;
+            ExtractMinimum(heap, expected);
+            AssertIsolated(extracted);
+
+            var replacement = heap.Insert(-1, 2);
+            expected.Add(2, (replacement, -1));
+            Assert.That(replacement, Is.Not.SameAs(extracted));
+            AssertIsolated(extracted);
+            heap.Validate(expected);
+
+            while (expected.Count > 0)
+                ExtractMinimum(heap, expected);
+            heap.Validate(expected);
+            AssertIsolated(extracted);
+        }
+
+        private static void AssertIsolated(object node)
+        {
+            Assert.That(Heap.Parent(node), Is.Null);
+            Assert.That(Heap.Get<object>(node, "Child"), Is.Null);
+            Assert.That(Heap.Get<object>(node, "Left"), Is.SameAs(node));
+            Assert.That(Heap.Get<object>(node, "Right"), Is.SameAs(node));
+            Assert.That(Heap.Get<int>(node, "Degree"), Is.Zero);
+            Assert.That(Heap.Get<bool>(node, "Marked"), Is.False);
         }
 
         [Test]

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
@@ -1,0 +1,301 @@
+using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Aardvark.Tests
+{
+    [TestFixture]
+    public class FibonacciHeapTests
+    {
+        // Reflection keeps the implementation internal and avoids a production friend assembly.
+        private sealed class Heap
+        {
+            private static readonly Type HeapType = typeof(ShortestPath<int>).Assembly
+                .GetType("Aardvark.Base.FibonacciHeap`1", true).MakeGenericType(typeof(int));
+            private static readonly Type NodeType = HeapType.GetMethod("DecreaseKey").GetParameters()[0].ParameterType;
+            private static readonly MethodInfo InsertMethod = HeapType.GetMethod("Insert", new[] { typeof(float), typeof(int) });
+            private static readonly MethodInfo ExtractMethod = HeapType.GetMethod("DeleteMin");
+            private static readonly MethodInfo DecreaseMethod = HeapType.GetMethod("DecreaseKey");
+            private readonly object _heap = Activator.CreateInstance(HeapType, true);
+
+            public object Insert(float key, int value) => InsertMethod.Invoke(_heap, new object[] { key, value });
+            public int Extract() => (int)ExtractMethod.Invoke(_heap, null);
+            public void Decrease(object node, float key) => DecreaseMethod.Invoke(_heap, new object[] { node, key });
+            public object Min => Field("_min");
+            public object Field(string name) => HeapType.GetField(name, BindingFlags.Instance | BindingFlags.NonPublic).GetValue(_heap);
+            public static T Get<T>(object node, string name) => (T)NodeType.GetProperty(name).GetValue(node);
+            public static object Parent(object node) => Get<object>(node, "Parent");
+            public static float Key(object node) => Get<float>(node, "Key");
+
+            public void Validate(Dictionary<int, (object Node, float Key)> expected)
+            {
+                Assert.That((int)Field("_n"), Is.EqualTo(expected.Count), "Node count");
+                Assert.That((Array)Field("_degreeTable"), Has.All.Null, "Scratch storage must not retain nodes");
+                if (expected.Count == 0)
+                {
+                    Assert.That(Min, Is.Null);
+                    return;
+                }
+
+                Assert.That(Min, Is.Not.Null);
+                Assert.That(Key(Min), Is.EqualTo(expected.Values.Min(e => e.Key)), "Minimum over all roots");
+                var seen = new HashSet<object>();
+                var rings = new Stack<(object Start, object Parent)>();
+                rings.Push((Min, null));
+                while (rings.Count > 0)
+                {
+                    var (start, parent) = rings.Pop();
+                    var node = start;
+                    int degree = 0;
+                    do
+                    {
+                        Assert.That(node, Is.Not.Null);
+                        Assert.That(seen.Add(node), Is.True, "Node appears in multiple rings or a ring does not close");
+                        int value = Get<int>(node, "Value");
+                        Assert.That(expected.ContainsKey(value), Is.True, "Unexpected node");
+                        Assert.That(node, Is.SameAs(expected[value].Node));
+                        Assert.That(Key(node), Is.EqualTo(expected[value].Key));
+                        Assert.That(Parent(node), Is.SameAs(parent), "Parent pointer");
+                        Assert.That(Get<object>(Get<object>(node, "Right"), "Left"), Is.SameAs(node));
+                        Assert.That(Get<object>(Get<object>(node, "Left"), "Right"), Is.SameAs(node));
+                        if (parent != null)
+                            Assert.That(Key(node), Is.GreaterThanOrEqualTo(Key(parent)), "Heap order");
+                        else
+                            Assert.That(Get<bool>(node, "Marked"), Is.False, "Roots must be unmarked");
+
+                        var child = Get<object>(node, "Child");
+                        if (child == null)
+                            Assert.That(Get<int>(node, "Degree"), Is.Zero);
+                        else
+                            rings.Push((child, node));
+                        degree++;
+                        node = Get<object>(node, "Right");
+                    } while (!ReferenceEquals(node, start));
+
+                    if (parent != null)
+                        Assert.That(Get<int>(parent, "Degree"), Is.EqualTo(degree), "Child count");
+                }
+                Assert.That(seen.Count, Is.EqualTo(expected.Count), "Reachable node count");
+            }
+        }
+
+        [Test]
+        public void ConsolidationIncludesUnlinkedRootsInMinimumSelection()
+        {
+            var heap = new Heap();
+            foreach (int key in new[] { 0, 3, 1, 2 }) heap.Insert(key, key);
+            CollectionAssert.AreEqual(new[] { 0, 1, 2, 3 }, Enumerable.Range(0, 4).Select(_ => heap.Extract()).ToArray());
+        }
+
+        [Test]
+        public void DecreasedChildBecomesNextMinimum()
+        {
+            var heap = new Heap();
+            object child = null;
+            foreach (int key in new[] { 0, 10, 20, 30, 40 })
+            {
+                var node = heap.Insert(key, key);
+                if (key == 20) child = node;
+            }
+            Assert.That(heap.Extract(), Is.Zero);
+            Assert.That(Heap.Parent(child), Is.Not.Null);
+            heap.Decrease(child, -1);
+            Assert.That(heap.Extract(), Is.EqualTo(20));
+        }
+
+        [TestCase(7)]
+        [TestCase(31)]
+        [TestCase(101)]
+        [TestCase(2027)]
+        public void MixedOperationsMatchReferencePriorityModel(int seed)
+        {
+            var random = new Random(seed);
+            var heap = new Heap();
+            var expected = new Dictionary<int, (object Node, float Key)>();
+            int nextId = 0;
+            for (int step = 0; step < 2500; step++)
+            {
+                int operation = random.Next(100);
+                if (expected.Count == 0 || operation < 42)
+                {
+                    float key = random.Next(-20, 101);
+                    expected.Add(nextId, (heap.Insert(key, nextId), key));
+                    nextId++;
+                }
+                else if (operation < 72)
+                {
+                    int id = expected.Keys.ElementAt(random.Next(expected.Count));
+                    var entry = expected[id];
+                    float key = entry.Key - random.Next(0, 41); // Includes equal-key decreases.
+                    heap.Decrease(entry.Node, key);
+                    expected[id] = (entry.Node, key);
+                }
+                else
+                {
+                    ExtractMinimum(heap, expected);
+                }
+                heap.Validate(expected);
+            }
+            while (expected.Count > 0)
+            {
+                ExtractMinimum(heap, expected);
+                heap.Validate(expected);
+            }
+        }
+
+        [Test]
+        public void EqualKeysAndHeapReusePreserveEveryNode()
+        {
+            var heap = new Heap();
+            var expected = new Dictionary<int, (object Node, float Key)>();
+            foreach (int count in new[] { 1, 2, 3, 32, 129, 1025, 7 })
+            {
+                for (int id = 0; id < count; id++) expected.Add(id, (heap.Insert(1, id), 1));
+                heap.Validate(expected);
+                while (expected.Count > 0)
+                {
+                    ExtractMinimum(heap, expected);
+                    heap.Validate(expected);
+                }
+            }
+        }
+
+        [TestCase(false)]
+        [TestCase(true)]
+        public void CutsMarkFirstLossAndCascadeThroughMarkedAncestors(bool markUpperFirst)
+        {
+            var heap = new Heap();
+            var expected = new Dictionary<int, (object Node, float Key)>();
+            for (int id = 0; id <= 256; id++) expected.Add(id, (heap.Insert(id, id), id));
+            Assert.That(heap.Extract(), Is.Zero);
+            expected.Remove(0);
+            heap.Validate(expected);
+
+            var lower = expected.Values.Select(e => e.Node).First(n =>
+                Heap.Get<int>(n, "Degree") >= 2 && Heap.Parent(n) != null &&
+                Heap.Parent(Heap.Parent(n)) != null);
+            var upper = Heap.Parent(lower);
+            var otherChild = expected.Values.Select(e => e.Node).First(n =>
+                ReferenceEquals(Heap.Parent(n), upper) && !ReferenceEquals(n, lower));
+            var children = expected.Values.Select(e => e.Node).Where(n => ReferenceEquals(Heap.Parent(n), lower)).Take(2).ToArray();
+
+            if (markUpperFirst)
+            {
+                Decrease(otherChild, -1);
+                Assert.That(Heap.Get<bool>(upper, "Marked"), Is.True);
+            }
+            Decrease(children[0], -2);
+            Assert.That(Heap.Get<bool>(lower, "Marked"), Is.True);
+            Decrease(children[1], -3);
+            Assert.That(Heap.Parent(lower), Is.Null);
+            Assert.That(Heap.Get<bool>(lower, "Marked"), Is.False);
+            if (!markUpperFirst)
+            {
+                Assert.That(Heap.Parent(upper), Is.Not.Null, "Cascade stops at the first unmarked ancestor");
+                Assert.That(Heap.Get<bool>(upper, "Marked"), Is.True, "That ancestor records its first lost child");
+                Decrease(upper, -4); // Cutting an already marked node also clears its mark.
+            }
+            Assert.That(Heap.Parent(upper), Is.Null);
+            Assert.That(Heap.Get<bool>(upper, "Marked"), Is.False);
+            while (expected.Count > 0)
+            {
+                ExtractMinimum(heap, expected);
+                heap.Validate(expected);
+            }
+
+            void Decrease(object node, float key)
+            {
+                heap.Decrease(node, key);
+                expected[Heap.Get<int>(node, "Value")] = (node, key);
+                heap.Validate(expected);
+            }
+        }
+
+        [Test]
+        public void EverySmallInsertionPermutationDrainsInOrder()
+        {
+            var keys = Enumerable.Range(0, 7).ToArray();
+            Permute(0);
+
+            void Permute(int start)
+            {
+                if (start == keys.Length)
+                {
+                    var heap = new Heap();
+                    foreach (int key in keys) heap.Insert(key, key);
+                    for (int key = 0; key < keys.Length; key++) Assert.That(heap.Extract(), Is.EqualTo(key));
+                    return;
+                }
+                for (int i = start; i < keys.Length; i++)
+                {
+                    (keys[start], keys[i]) = (keys[i], keys[start]);
+                    Permute(start + 1);
+                    (keys[start], keys[i]) = (keys[i], keys[start]);
+                }
+            }
+        }
+
+        [Test]
+        public void PromotedChildrenLoseMarksAndExtractedHandlesAreIsolated()
+        {
+            var heap = new Heap();
+            var expected = new Dictionary<int, (object Node, float Key)>();
+            for (int id = 0; id <= 256; id++) expected.Add(id, (heap.Insert(id, id), id));
+            ExtractMinimum(heap, expected);
+            var root = heap.Min;
+            var parent = expected.Values.Select(e => e.Node).First(n =>
+                ReferenceEquals(Heap.Parent(n), root) && Heap.Get<int>(n, "Degree") > 0);
+            var child = Heap.Get<object>(parent, "Child");
+            heap.Decrease(child, -1);
+            expected[Heap.Get<int>(child, "Value")] = (child, -1);
+            Assert.That(Heap.Get<bool>(parent, "Marked"), Is.True);
+            heap.Decrease(root, -2);
+            expected[Heap.Get<int>(root, "Value")] = (root, -2);
+            ExtractMinimum(heap, expected);
+            Assert.That(Heap.Get<bool>(parent, "Marked"), Is.False);
+            Assert.That(Heap.Get<object>(root, "Child"), Is.Null);
+            Assert.That(Heap.Get<int>(root, "Degree"), Is.Zero);
+            Assert.That(Heap.Get<object>(root, "Left"), Is.SameAs(root));
+            Assert.That(Heap.Get<object>(root, "Right"), Is.SameAs(root));
+            heap.Validate(expected);
+        }
+
+        [Test]
+        public void DegreeStorageGrowsIsClearedAndIsReusedAfterDraining()
+        {
+            var heap = new Heap();
+            for (int i = 0; i <= 16; i++) heap.Insert(i, i);
+            heap.Extract();
+            var small = (Array)heap.Field("_degreeTable");
+            Assert.That(small.Length, Is.GreaterThan(0));
+            for (int i = 0; i < 16; i++) heap.Extract();
+
+            for (int i = 0; i <= 4096; i++) heap.Insert(i, i);
+            heap.Extract();
+            var grown = (Array)heap.Field("_degreeTable");
+            Assert.That(grown.Length, Is.GreaterThan(small.Length));
+            for (int i = 0; i < 4096; i++)
+            {
+                heap.Extract();
+                Assert.That((Array)heap.Field("_degreeTable"), Is.SameAs(grown));
+                Assert.That(grown, Has.All.Null);
+            }
+            for (int i = 0; i <= 4096; i++) heap.Insert(i, i);
+            heap.Extract();
+            Assert.That((Array)heap.Field("_degreeTable"), Is.SameAs(grown));
+            Assert.That(grown, Has.All.Null);
+        }
+
+        private static void ExtractMinimum(Heap heap, Dictionary<int, (object Node, float Key)> expected)
+        {
+            float minimum = expected.Values.Min(e => e.Key);
+            int value = heap.Extract();
+            Assert.That(expected.ContainsKey(value), Is.True);
+            Assert.That(expected[value].Key, Is.EqualTo(minimum));
+            expected.Remove(value);
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/FibonacciHeapTests.cs
@@ -32,7 +32,6 @@ namespace Aardvark.Tests
 
             public void Validate(Dictionary<int, (object Node, float Key)> expected)
             {
-                Assert.That((int)Field("_n"), Is.EqualTo(expected.Count), "Node count");
                 Assert.That((Array)Field("_degreeTable"), Has.All.Null, "Scratch storage must not retain nodes");
                 if (expected.Count == 0)
                 {

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/ShortestPathTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/ShortestPathTests.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -299,6 +300,138 @@ namespace Aardvark.Tests
             var exception = Assert.Throws<InvalidOperationException>(() => shortestPath.Cancel());
             Assert.AreEqual("Cost calculation failed.", exception.Message);
             costEntered.Dispose();
+        }
+
+        [Test, Timeout(30000)]
+        public void DecreasedFrontierNodeIsExpandedBeforeMoreExpensivePaths()
+        {
+            var costs = new float[6, 6];
+            var edges = new List<(int, int)>();
+            foreach (var (a, b, cost) in new[]
+            {
+                (0, 1, 10), (0, 2, 20), (0, 3, 30), (0, 4, 40), (0, 5, 50),
+                (1, 3, 1), (3, 2, 1)
+            })
+            {
+                edges.Add((a, b));
+                SetCost(costs, a, b, cost);
+            }
+
+            var shortestPath = new ShortestPath<int>(Enumerable.Range(0, 6).ToList(), edges, (a, b) => costs[a, b]);
+            try
+            {
+                shortestPath.CalculateShortestPathsByIndex(0);
+                WaitForCalculation(shortestPath);
+                CollectionAssert.AreEqual(new[] { 2, 3, 1 }, shortestPath.GetMinimalPathByIndex(2));
+                Assert.That(PathCost(shortestPath.GetMinimalPathByIndex(2), 0, costs), Is.EqualTo(12));
+            }
+            finally
+            {
+                shortestPath.Cancel();
+            }
+        }
+
+        [TestCase(7, 16, false)]
+        [TestCase(31, 64, false)]
+        [TestCase(101, 128, false)]
+        [TestCase(7, 16, true)]
+        [TestCase(31, 64, true)]
+        [TestCase(101, 128, true)]
+        [Timeout(30000)]
+        public void SeededGraphsMatchReferenceDijkstra(int randomSeed, int count, bool directed)
+        {
+            var random = new Random(randomSeed);
+            var costs = new float[count, count];
+            var neighbors = Enumerable.Range(0, count).Select(_ => new List<int>()).ToArray();
+            for (int a = 0; a < count - 1; a++) // The last node is deliberately unreachable.
+            {
+                for (int b = directed ? 0 : a + 1; b < count - 1; b++)
+                {
+                    if (a == b || random.Next(5) != 0) continue;
+                    costs[a, b] = random.Next(0, 101); // Finite, non-negative, with ties and zero costs.
+                    neighbors[a].Add(b);
+                    if (!directed)
+                    {
+                        costs[b, a] = costs[a, b];
+                        neighbors[b].Add(a);
+                    }
+                }
+            }
+
+            var shortestPath = new ShortestPath<int>(Enumerable.Range(0, count).ToArray(), neighbors, (a, b) => costs[a, b]);
+            try
+            {
+                foreach (int seed in new[] { 0, count / 2, count - 1 })
+                {
+                    var expected = ReferenceDijkstra(neighbors, costs, seed);
+                    shortestPath.CalculateShortestPathsByIndex(seed);
+                    WaitForCalculation(shortestPath);
+                    for (int target = 0; target < count; target++)
+                    {
+                        var path = shortestPath.GetMinimalPathByIndex(target);
+                        if (target == seed)
+                            Assert.That(path, Is.Empty, "Seed paths exclude the seed");
+                        else if (float.IsPositiveInfinity(expected[target]))
+                            CollectionAssert.AreEqual(new[] { target, seed }, path, "Unreachable path convention");
+                        else
+                        {
+                            Assert.That(path[0], Is.EqualTo(target));
+                            Assert.That(path, Does.Not.Contain(seed));
+                            Assert.That(path.Distinct().Count(), Is.EqualTo(path.Count), "No predecessor cycle");
+                            int previous = seed;
+                            for (int i = path.Count - 1; i >= 0; i--)
+                            {
+                                Assert.That(neighbors[previous], Does.Contain(path[i]), "Path must follow graph edges");
+                                previous = path[i];
+                            }
+                            Assert.That(PathCost(path, seed, costs), Is.EqualTo(expected[target]), $"Seed {seed}, target {target}");
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                shortestPath.Cancel();
+            }
+        }
+
+        private static float[] ReferenceDijkstra(List<int>[] neighbors, float[,] costs, int seed)
+        {
+            var distances = Enumerable.Repeat(float.PositiveInfinity, neighbors.Length).ToArray();
+            var expanded = new bool[neighbors.Length];
+            distances[seed] = 0;
+            for (int i = 0; i < neighbors.Length; i++)
+            {
+                int next = -1;
+                for (int node = 0; node < neighbors.Length; node++)
+                    if (!expanded[node] && (next == -1 || distances[node] < distances[next])) next = node;
+                if (next == -1 || float.IsPositiveInfinity(distances[next])) break;
+                expanded[next] = true;
+                foreach (int neighbor in neighbors[next])
+                    distances[neighbor] = Math.Min(distances[neighbor], distances[next] + costs[next, neighbor]);
+            }
+            return distances;
+        }
+
+        private static float PathCost(List<int> path, int seed, float[,] costs)
+        {
+            float cost = 0;
+            int previous = seed;
+            for (int i = path.Count - 1; i >= 0; i--)
+            {
+                cost += costs[previous, path[i]];
+                previous = path[i];
+            }
+            return cost;
+        }
+
+        private static void WaitForCalculation(ShortestPath<int> shortestPath)
+        {
+            // Await the actual worker, not an expected path that could mask a failed calculation.
+            var run = typeof(ShortestPath<int>).GetField("m_currentRun", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(shortestPath);
+            var task = (Task)run.GetType().GetProperty("Task").GetValue(run);
+            AssertTaskCompletes(task);
         }
 
         private static void SetCost(float[,] costs, int a, int b, float value)


### PR DESCRIPTION
## Summary

Correct root consolidation, minimum selection, and cascading cuts in the internal Fibonacci heap while preserving `ShortestPath<T>` asynchronous lifecycle and path-return conventions.

- Process every root exactly once and preserve circular links, parents, degrees, and marks.
- Reuse safely growing degree and node-registry storage without retaining extracted nodes.
- Use indexed intrusive links to avoid GC write barriers during ring mutation.
- Cover structural invariants, 5,040 insertion permutations, deterministic mixed operations, cascading cuts, and reference-Dijkstra graph costs.
- Document finite non-negative cost requirements and add an unreleased note.

## Validation

- Focused Release tests: 26 passed.
- Full maintained suites: 2,172 passed, 31 existing skips, 0 failed.
- Full build: 0 warnings, 0 errors.
- Documentation check passed.

## Performance

Matched warmed Release benchmarks against unchanged `c79192f8` were run twice per version with reversed order. All eight retained workloads improved by 10.6–103.5%, including 22.8% for 4,096-item insertion/drain and 16.5% for insertion/decrease/drain. Allocations fell 28.2–75.1%.

[Measurements and reproduction command](https://github.com/aardvark-platform/aardvark.base/blob/d1e00e2769e28bde830a3bee03042319bd8d242b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/ShortestPathBenchmark.md).

Closes #131.