### PR TITLE
Make hierarchical cell intersections exact

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+- [Base] Made hierarchical cell intersections exact across coordinate and exponent ranges
 - [Base] Corrected winding- and translation-stable 2D and 3D polygon centroids
 - [Base] Corrected complex magnitude, reciprocal, division, and square roots at extreme finite scales
 - [Base] Corrected robust ray-sphere intersections and closest-hit accumulation

--- a/ai/SEMANTICS_GEOMETRY_CORE.md
+++ b/ai/SEMANTICS_GEOMETRY_CORE.md
@@ -157,6 +157,36 @@ Semantics (`Ray3_auto.cs`, `FastRay3d.Intersects`):
 - Flag-returning overloads report the union of every box face tied at each interval bound; a corner hit can therefore return two or three face bits. Masked overloads report only selected faces.
 - Axes with zero direction components are handled via `DirFlags`; the ray origin must lie between the slabs of such an axis for a hit.
 
+## Hierarchical Cell Intersections
+
+`Cell.Intersects(Cell)` and `Cell2d.Intersects(Cell2d)` compare valid hierarchical
+cells exactly using integer grid coordinates and exponents. They do not convert
+valid cells to floating-point boxes, allocate memory, or add one to an Int64
+coordinate. The result remains exact across the full coordinate and exponent
+ranges, including sizes and locations outside double precision or range.
+
+- An ordinary axis interval is mathematically `[i * 2^e, (i + 1) * 2^e)`;
+  centered-origin cells use `[-2^(e-1), 2^(e-1))` on every axis.
+- Intersection requires positive volume (`Cell`) or positive area (`Cell2d`).
+  Face-, edge-, and corner-only contacts are excluded. The query is symmetric,
+  and a cell intersects itself.
+- Ordinary grid cells either nest or have disjoint interiors. Align the smaller
+  cell to the larger exponent with arithmetic right shifts, then compare grid
+  coordinates. Exponent subtraction is widened before arithmetic, and shift
+  counts saturate at 63 rather than wrapping through C# shift masking.
+- Two centered-origin cells always overlap. A centered cell `C` overlaps an
+  ordinary cell `O` exactly when every coordinate of `O`, shifted right by
+  `clamp((long)C.Exponent - O.Exponent - 1, 0, 63)`, is either `-1` or `0`.
+  This includes partial overlap when neither cell contains the other.
+- The equality fast path includes `Invalid.Intersects(Invalid) == true`.
+  Other Invalid-sentinel pairs retain the previous bounding-box behavior through
+  a compatibility path, including degenerate and NaN bounds; Invalid is not
+  redefined as an empty cell. For example, it intersects a unit-size centered
+  cell but not the ordinary `Unit` cell.
+
+This exactness guarantee is specific to `Intersects`. `Contains`, `BoundingBox`,
+constructors, and hierarchy operations retain their existing behavior.
+
 ## Box/Plane Intersection
 
 `Box2f`/`Box2d` plane intersections use the full plane equation `Normal dot point == Distance`:
@@ -252,6 +282,8 @@ The closest-point and minimal-distance extensions in `SpecialPoints_auto.cs` tre
 
 ## Source Anchors
 
+- `src/Aardvark.Base/Math/RangesBoxes/Cell.cs` (`Cell.Intersects`, exact integer-grid overlap and Invalid compatibility)
+- `src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs` (`Cell2d.Intersects`, exact integer-grid overlap and Invalid compatibility)
 - `src/Aardvark.Base/Math/Trafos/Matrix_auto.cs` (`TransformPos`, `TransformDir`, `TransformPosProj`)
 - `src/Aardvark.Base/Math/Trafos/Trafo_auto.cs` (`Trafo3d`, `Forward`, `Backward`)
 - `src/Aardvark.Base/Geometry/IntersectionTests_auto.cs` (`Box3d.Intersects(Ray3d, out t)`, `Box2f`/`Box2d` plane intersections)

--- a/src/Aardvark.Base/Math/RangesBoxes/Cell.cs
+++ b/src/Aardvark.Base/Math/RangesBoxes/Cell.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -257,15 +258,58 @@ public readonly partial struct Cell : IEquatable<Cell>
     }
 
     /// <summary>
-    /// Returns true if two cells intersect each other (or one contains the other).
-    /// Cells DO NOT intersect if only touching from the outside.
-    /// A cell intersects itself.
+    /// Returns true if valid cells have positive-volume overlap, including containment.
+    /// Uses exact integer grid coordinates and exponents, even beyond floating-point range or precision.
+    /// Face-, edge-, and corner-only contacts do not intersect. Every cell intersects itself.
     /// </summary>
+    /// <remarks>
+    /// Centered-origin cells overlap each other and may partially overlap ordinary grid cells.
+    /// Invalid-sentinel pairs retain the legacy bounding-box behavior, including Invalid intersecting itself.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Intersects(Cell other)
     {
         if (X == other.X && Y == other.Y && Z == other.Z && Exponent == other.Exponent) return true;
-        return BoundingBox.Intersects(other.BoundingBox);
+        return IntersectsUnequal(other);
     }
+
+    private bool IntersectsUnequal(Cell other)
+    {
+        if (IsInvalid || other.IsInvalid) return IntersectsInvalid(other);
+        if (IsCenteredAtOrigin)
+            return other.IsCenteredAtOrigin || IntersectsCentered(Exponent, other);
+        if (other.IsCenteredAtOrigin)
+            return IntersectsCentered(other.Exponent, this);
+
+        // Ordinary grid cells either nest or have disjoint interiors. Align the smaller
+        // cell to the coarser grid. Widen before subtraction and saturate instead of masking.
+        long delta = (long)Exponent - other.Exponent;
+        if (delta >= 0)
+        {
+            int shift = (int)Math.Min(delta, 63);
+            return X == (other.X >> shift) && Y == (other.Y >> shift) && Z == (other.Z >> shift);
+        }
+        else
+        {
+            int shift = (int)Math.Min(-delta, 63);
+            return (X >> shift) == other.X && (Y >> shift) == other.Y && (Z >> shift) == other.Z;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IntersectsCentered(int centeredExponent, Cell ordinary)
+    {
+        // The centered cell extends half its size to either side of zero. When it is
+        // smaller, only origin-adjacent ordinary cells can overlap it (possibly partially).
+        long delta = (long)centeredExponent - ordinary.Exponent - 1;
+        int shift = delta <= 0 ? 0 : delta >= 63 ? 63 : (int)delta;
+        long x = ordinary.X >> shift, y = ordinary.Y >> shift, z = ordinary.Z >> shift;
+        return x >= -1 && x <= 0 && y >= -1 && y <= 0 && z >= -1 && z <= 0;
+    }
+
+    // Keep legacy sentinel semantics, including degenerate/NaN bounds, off the valid-cell path.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool IntersectsInvalid(Cell other) => BoundingBox.Intersects(other.BoundingBox);
 
     /// <summary>
     /// The 8 subcells created by splitting each axis in half.

--- a/src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs
+++ b/src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Runtime.Serialization;
 using System.Text.Json.Serialization;
 
@@ -260,15 +261,58 @@ public readonly partial struct Cell2d : IEquatable<Cell2d>
     }
 
     /// <summary>
-    /// Returns true if two cells intersect each other (or one contains the other).
-    /// Cells DO NOT intersect if only touching from the outside.
-    /// A cell intersects itself.
+    /// Returns true if valid cells have positive-area overlap, including containment.
+    /// Uses exact integer grid coordinates and exponents, even beyond floating-point range or precision.
+    /// Edge- and corner-only contacts do not intersect. Every cell intersects itself.
     /// </summary>
+    /// <remarks>
+    /// Centered-origin cells overlap each other and may partially overlap ordinary grid cells.
+    /// Invalid-sentinel pairs retain the legacy bounding-box behavior, including Invalid intersecting itself.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool Intersects(Cell2d other)
     {
         if (X == other.X && Y == other.Y && Exponent == other.Exponent) return true;
-        return BoundingBox.Intersects(other.BoundingBox);
+        return IntersectsUnequal(other);
     }
+
+    private bool IntersectsUnequal(Cell2d other)
+    {
+        if (IsInvalid || other.IsInvalid) return IntersectsInvalid(other);
+        if (IsCenteredAtOrigin)
+            return other.IsCenteredAtOrigin || IntersectsCentered(Exponent, other);
+        if (other.IsCenteredAtOrigin)
+            return IntersectsCentered(other.Exponent, this);
+
+        // Ordinary grid cells either nest or have disjoint interiors. Align the smaller
+        // cell to the coarser grid. Widen before subtraction and saturate instead of masking.
+        long delta = (long)Exponent - other.Exponent;
+        if (delta >= 0)
+        {
+            int shift = (int)Math.Min(delta, 63);
+            return X == (other.X >> shift) && Y == (other.Y >> shift);
+        }
+        else
+        {
+            int shift = (int)Math.Min(-delta, 63);
+            return (X >> shift) == other.X && (Y >> shift) == other.Y;
+        }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IntersectsCentered(int centeredExponent, Cell2d ordinary)
+    {
+        // The centered cell extends half its size to either side of zero. When it is
+        // smaller, only origin-adjacent ordinary cells can overlap it (possibly partially).
+        long delta = (long)centeredExponent - ordinary.Exponent - 1;
+        int shift = delta <= 0 ? 0 : delta >= 63 ? 63 : (int)delta;
+        long x = ordinary.X >> shift, y = ordinary.Y >> shift;
+        return x >= -1 && x <= 0 && y >= -1 && y <= 0;
+    }
+
+    // Keep legacy sentinel semantics, including degenerate/NaN bounds, off the valid-cell path.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private bool IntersectsInvalid(Cell2d other) => BoundingBox.Intersects(other.BoundingBox);
 
     /// <summary>
     /// Gets the 4 subcells.

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/CellIntersectionBenchmark.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/CellIntersectionBenchmark.cs
@@ -1,0 +1,133 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using System;
+
+namespace Aardvark.Base.Benchmarks.Geometry
+{
+    // dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- --filter '*CellIntersectionBenchmark*'
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    public class CellIntersectionBenchmark
+    {
+        private const int PairCount = 1024;
+        private Cell[] _a3, _b3;
+        private Cell2d[] _a2, _b2;
+
+        [Params("Equal", "Overlapping", "Disjoint", "Centered", "MixedScale")]
+        public string Case { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _a3 = new Cell[PairCount];
+            _b3 = new Cell[PairCount];
+            _a2 = new Cell2d[PairCount];
+            _b2 = new Cell2d[PairCount];
+            var random = new Random(731);
+            for (int i = 0; i < PairCount; i++)
+            {
+                int exponent = random.Next(-8, 9);
+                var a = new Cell(random.Next(-16, 17), random.Next(-16, 17), random.Next(-16, 17), exponent);
+                Cell b;
+                switch (Case)
+                {
+                    case "Equal":
+                        if (i % 4 == 0) a = new Cell(exponent);
+                        b = a;
+                        break;
+                    case "Overlapping":
+                        int gap = random.Next(1, 11);
+                        int scale = 1 << gap;
+                        b = new Cell(a.X * scale + random.Next(scale), a.Y * scale + random.Next(scale),
+                            a.Z * scale + random.Next(scale), exponent - gap);
+                        break;
+                    case "Disjoint":
+                        b = i % 2 == 0 ? new Cell(a.X + 2, a.Y, a.Z, exponent) : new Cell(a.X, a.Y + 2, a.Z, exponent);
+                        break;
+                    case "Centered":
+                        a = new Cell(exponent);
+                        b = (i % 4) switch
+                        {
+                            0 => new Cell(exponent + 1),
+                            1 => new Cell(-1, 0, -1, exponent - 2),
+                            2 => new Cell(0, -1, 0, exponent + 2),
+                            _ => new Cell(2, 0, 0, exponent)
+                        };
+                        break;
+                    case "MixedScale":
+                        (a, b) = (i % 8) switch
+                        {
+                            0 => (new Cell(1L << 53, 0, 0, 0), new Cell(1L << 54, 0, 0, -1)),
+                            1 => (new Cell(0, 0, 0, -1100), new Cell(0, 0, 0, -1101)),
+                            2 => (new Cell(0, 0, 0, 1100), new Cell(2, 0, 0, 1100)),
+                            3 => (new Cell(-1, 0, 0, 64), new Cell(long.MinValue, 0, 0, 0)),
+                            4 => (new Cell(0, 0, 0, int.MaxValue), new Cell(long.MaxValue, 0, 0, int.MinValue)),
+                            5 => (new Cell(-1100), new Cell(0, 0, 0, 1100)),
+                            6 => (new Cell(-1, 0, 0, 65), new Cell(long.MaxValue, 0, 0, 0)),
+                            _ => (new Cell(0, 0, 0, 10), new Cell(17, 33, 5, -8))
+                        };
+                        break;
+                    default:
+                        throw new InvalidOperationException("Unknown benchmark case.");
+                }
+                // Exercise both receiver directions on exactly the same prebuilt pairs.
+                if ((i & 1) != 0) (a, b) = (b, a);
+                _a3[i] = a;
+                _b3[i] = b;
+                _a2[i] = new Cell2d(a.X, a.Y, a.Exponent);
+                _b2[i] = new Cell2d(b.X, b.Y, b.Exponent);
+            }
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = PairCount)]
+        [BenchmarkCategory("Cell")]
+        public int PreviousCell()
+        {
+            int hits = 0;
+            for (int i = 0; i < PairCount; i++) if (Previous(in _a3[i], _b3[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = PairCount)]
+        [BenchmarkCategory("Cell")]
+        public int IntegerCell()
+        {
+            int hits = 0;
+            for (int i = 0; i < PairCount; i++) if (_a3[i].Intersects(_b3[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = PairCount)]
+        [BenchmarkCategory("Cell2d")]
+        public int PreviousCell2d()
+        {
+            int hits = 0;
+            for (int i = 0; i < PairCount; i++) if (Previous(in _a2[i], _b2[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = PairCount)]
+        [BenchmarkCategory("Cell2d")]
+        public int IntegerCell2d()
+        {
+            int hits = 0;
+            for (int i = 0; i < PairCount; i++) if (_a2[i].Intersects(_b2[i])) hits++;
+            return hits;
+        }
+
+        // Previous instance-method bodies at d1e00e27. The readonly by-reference
+        // first argument matches the original receiver; BoundingBox is unchanged.
+        private static bool Previous(in Cell a, Cell b)
+        {
+            if (a.X == b.X && a.Y == b.Y && a.Z == b.Z && a.Exponent == b.Exponent) return true;
+            return a.BoundingBox.Intersects(b.BoundingBox);
+        }
+
+        private static bool Previous(in Cell2d a, Cell2d b)
+        {
+            if (a.X == b.X && a.Y == b.Y && a.Exponent == b.Exponent) return true;
+            return a.BoundingBox.Intersects(b.BoundingBox);
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/CellIntersectionBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/CellIntersectionBenchmark.md
@@ -1,0 +1,52 @@
+# Exact cell-intersection benchmarks
+
+Tracking: [#133](https://github.com/aardvark-platform/aardvark.base/issues/133).
+
+```sh
+dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
+  --filter '*CellIntersectionBenchmark*' \
+  --warmupCount 8 --iterationCount 20 --iterationTime 1000 --buildTimeout 600
+```
+
+The fixture compares the previous `Intersects` bodies at `d1e00e27` with the
+integer implementation. Baseline receivers are passed by readonly reference,
+matching the original instance methods; `BoundingBox` is unchanged. Each
+invocation processes the same 1,024 prebuilt pairs, alternating receiver order.
+Input generation and array allocation are outside timing. Reported time and
+allocations are per pair, not per batch.
+
+- **Equal:** ordinary and centered self-intersections.
+- **Overlapping:** ordinary parents and children at ordinary representable scales.
+- **Disjoint:** separated ordinary cells at the same exponent.
+- **Centered:** centered/centered and centered/ordinary hits and misses, including partial overlap.
+- **MixedScale:** large coordinates, underflow, overflow, saturated shifts and full-int-range exponent differences.
+
+Mixed-scale answers intentionally differ where the previous floating-point
+implementation was incorrect. Correctness is checked independently by regression
+and BigInteger interval-oracle tests, not by requiring the two benchmark hit
+counts to agree. All benchmark pairs are valid cells; Invalid compatibility has
+separate characterization tests.
+
+## Results
+
+Release, .NET 8.0.26, isolated BenchmarkDotNet processes on the same processor
+affinity, eight warmup iterations and twenty one-second target iterations:
+
+| Type | Case | Previous (ns) | Integer (ns) | Speedup | Allocated bytes, both |
+| --- | --- | ---: | ---: | ---: | ---: |
+| Cell | Equal | 1.452 | 1.411 | 1.03x | 0 |
+| Cell | Overlapping | 26.532 | 3.576 | 7.42x | 0 |
+| Cell | Disjoint | 24.624 | 2.875 | 8.56x | 0 |
+| Cell | Centered | 24.941 | 4.802 | 5.19x | 0 |
+| Cell | MixedScale | 24.828 | 3.652 | 6.80x | 0 |
+| Cell2d | Equal | 1.191 | 1.138 | 1.05x | 0 |
+| Cell2d | Overlapping | 24.951 | 3.282 | 7.60x | 0 |
+| Cell2d | Disjoint | 23.343 | 3.553 | 6.57x | 0 |
+| Cell2d | Centered | 24.824 | 4.292 | 5.78x | 0 |
+| Cell2d | MixedScale | 24.150 | 3.464 | 6.97x | 0 |
+
+Non-equal queries improve 5.2–8.6x. Equality retains its fast path without a
+measured regression; its tiny differences should not be treated as substantial
+speedups. Every measured workload remains allocation-free. The final isolated
+run completed without BenchmarkDotNet warnings; shorter preliminary in-process
+iterations were insufficient for reliable equality-path comparisons.

--- a/src/Tests/Aardvark.Base.Tests/RangesBoxes/Cell2dTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/RangesBoxes/Cell2dTests.cs
@@ -531,6 +531,39 @@ namespace Aardvark.Tests
 
         #endregion
 
+        #region exact intersections
+
+        private static IEnumerable<TestCaseData> ExactIntersectionCases => CellIntersectionTestData.Cases(2);
+        private static IEnumerable<TestCaseData> InvalidIntersectionCases => CellIntersectionTestData.InvalidCases(2);
+
+        [TestCaseSource(nameof(ExactIntersectionCases))]
+        public void IntersectsExactly(Cell2d a, Cell2d b, bool expected)
+        {
+            Assert.That(a.IsValid && b.IsValid, Is.True, "Exact semantics apply to valid cells");
+            Assert.That(a.Intersects(b), Is.EqualTo(expected), $"{a} versus {b}");
+            Assert.That(b.Intersects(a), Is.EqualTo(expected), "Symmetry");
+            Assert.That(a.Intersects(a), Is.True, "Self-intersection");
+            Assert.That(b.Intersects(b), Is.True, "Self-intersection");
+        }
+
+        [TestCase(7)]
+        [TestCase(31)]
+        [TestCase(2027)]
+        public void IntersectsMatchesBigIntegerIntervals(int seed)
+            => CellIntersectionTestData.CompareRandomPairs(2, seed);
+
+        [TestCaseSource(nameof(InvalidIntersectionCases))]
+        public void IntersectsPreservesInvalidCompatibility(Cell2d other, bool expected)
+        {
+            var invalid = Cell2d.Invalid;
+            bool legacy = invalid == other || invalid.BoundingBox.Intersects(other.BoundingBox);
+            Assert.That(legacy, Is.EqualTo(expected), "Characterized legacy sentinel behavior");
+            Assert.That(invalid.Intersects(other), Is.EqualTo(expected));
+            Assert.That(other.Intersects(invalid), Is.EqualTo(expected));
+        }
+
+        #endregion
+
         #region contains/intersects
 
         [Test]

--- a/src/Tests/Aardvark.Base.Tests/RangesBoxes/CellIntersectionTestData.cs
+++ b/src/Tests/Aardvark.Base.Tests/RangesBoxes/CellIntersectionTestData.cs
@@ -1,0 +1,223 @@
+using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+
+namespace Aardvark.Tests
+{
+    internal static class CellIntersectionTestData
+    {
+        // Cell is also a convenient input carrier for the 2D cases; only X and Y
+        // participate there. Axis-specific cases are generated for the requested dimension.
+        public static IEnumerable<TestCaseData> Cases(int dimensions)
+        {
+            foreach (var (name, a, b, expected) in Pairs(dimensions))
+            {
+                yield return dimensions == 3
+                    ? new TestCaseData(a, b, expected).SetName("IntersectsExactly_" + name)
+                    : new TestCaseData(Project(a), Project(b), expected).SetName("IntersectsExactly_" + name);
+            }
+        }
+
+        private static IEnumerable<(string Name, Cell A, Cell B, bool Expected)> Pairs(int dimensions)
+        {
+            yield return ("BeyondDoublePrecision", new Cell(1L << 53, 0, 0, 0), new Cell(1L << 54, 0, 0, -1), true);
+            yield return ("UnderflowParentChild", new Cell(0, 0, 0, -1100), new Cell(0, 0, 0, -1101), true);
+            yield return ("OverflowDisjoint", new Cell(0, 0, 0, 1100), new Cell(2, 0, 0, 1100), false);
+
+            foreach (int gap in new[] { 0, 1, 62, 63, 64, 65, 127, int.MaxValue })
+            {
+                // A shift by 63 or more is sign extension, not C#'s masked shift count.
+                long positiveParent = long.MaxValue >> Math.Min(gap, 63);
+                long negativeParent = long.MinValue >> Math.Min(gap, 63);
+                var finePositive = new Cell(long.MaxValue, 0, 0, -1);
+                var fineNegative = new Cell(long.MinValue, 0, 0, -1);
+                yield return ($"PositiveGap{gap}", new Cell(positiveParent, 0, 0, gap - 1), finePositive, true);
+                yield return ($"NegativeGap{gap}", new Cell(negativeParent, 0, 0, gap - 1), fineNegative, true);
+                yield return ($"DisjointPositiveGap{gap}", new Cell(-1, 0, 0, gap - 1), finePositive, false);
+                yield return ($"DisjointNegativeGap{gap}", new Cell(0, 0, 0, gap - 1), fineNegative, false);
+            }
+
+            yield return ("FullExponentRangePositive", new Cell(0, 0, 0, int.MaxValue), new Cell(long.MaxValue, 0, 0, int.MinValue), true);
+            yield return ("FullExponentRangeNegative", new Cell(-1, -1, -1, int.MaxValue), new Cell(long.MinValue, -1, -1, int.MinValue), true);
+            yield return ("FullExponentRangeDisjoint", new Cell(1, 0, 0, int.MaxValue), new Cell(long.MaxValue, 0, 0, int.MinValue), false);
+            yield return ("FullExponentRangeAcrossOrigin", new Cell(0, 0, 0, int.MaxValue), new Cell(long.MinValue, 0, 0, int.MinValue), false);
+            yield return ("SameCoordinatesDifferentScale", new Cell(1, 0, 0, 0), new Cell(1, 0, 0, -1), false);
+            yield return ("LongMaxEndpoint", new Cell(long.MaxValue, 0, 0, 0), new Cell(long.MaxValue >> 1, 0, 0, 1), true);
+            yield return ("LongMinEndpoint", new Cell(long.MinValue, 0, 0, 0), new Cell(long.MinValue >> 1, 0, 0, 1), true);
+
+            var smallestCentered = new Cell(long.MaxValue, long.MaxValue, long.MaxValue, int.MinValue);
+            yield return ("CenteredFullExponentRange", smallestCentered, new Cell(int.MaxValue), true);
+            yield return ("CenteredNegativeExponentGapPositiveOutside", smallestCentered, new Cell(1, 0, 0, 0), false);
+            yield return ("CenteredNegativeExponentGapNegativeOutside", smallestCentered, new Cell(-2, 0, 0, 0), false);
+            yield return ("CenteredUnderflow", new Cell(-1100), new Cell(-1101), true);
+            yield return ("CenteredOverflow", new Cell(1100), new Cell(1101), true);
+            yield return ("CenteredContainsAllFiniteCoordinates", new Cell(int.MaxValue), new Cell(long.MinValue, long.MaxValue, 0, int.MinValue), true);
+
+            foreach (int centeredExponent in new[] { int.MinValue, -1100, -1, 0, 1, 62, 63, 64, 65, 1100, int.MaxValue })
+            {
+                var centered = new Cell(long.MaxValue, long.MaxValue, long.MaxValue, centeredExponent);
+                // Tiny centered cells still partially overlap every origin-adjacent ordinary cell.
+                for (int signs = 0; signs < (1 << dimensions); signs++)
+                {
+                    var ordinary = new Cell((signs & 1) == 0 ? -1 : 0, (signs & 2) == 0 ? -1 : 0,
+                        (signs & 4) == 0 ? -1 : 0, int.MaxValue);
+                    yield return ($"CenteredPartial{centeredExponent}_{signs}", centered, ordinary, true);
+                }
+            }
+
+            foreach (int gap in new[] { 0, 1, 62, 63, 64, 65 })
+            {
+                // C's radius is 2^(gap-1), while the ordinary cell has unit size.
+                var centered = new Cell(gap);
+                long insidePositive = gap == 0 ? 0 : gap >= 64 ? long.MaxValue : (1L << (gap - 1)) - 1;
+                long insideNegative = gap == 0 ? -1 : gap >= 64 ? long.MinValue : -(1L << (gap - 1));
+                yield return ($"CenteredPositiveGap{gap}", centered, new Cell(insidePositive, 0, 0, 0), true);
+                yield return ($"CenteredNegativeGap{gap}", centered, new Cell(insideNegative, 0, 0, 0), true);
+                if (gap < 64)
+                {
+                    long outsidePositive = gap == 0 ? 1 : 1L << (gap - 1);
+                    long outsideNegative = gap == 0 ? -2 : -(1L << (gap - 1)) - 1;
+                    for (int axis = 0; axis < dimensions; axis++)
+                    {
+                        yield return ($"CenteredPositiveBoundary{gap}_{axis}", centered, OnAxis(axis, outsidePositive, 0), false);
+                        yield return ($"CenteredNegativeBoundary{gap}_{axis}", centered, OnAxis(axis, outsideNegative, 0), false);
+                    }
+                }
+            }
+
+            foreach (int exponent in new[] { int.MinValue, -1100, 0, 1100, int.MaxValue })
+            {
+                // Every nonempty subset of axes: faces, edges, and corners. No coordinate+1 in production.
+                for (int axes = 1; axes < (1 << dimensions); axes++)
+                {
+                    var neighbor = new Cell(axes & 1, (axes >> 1) & 1, (axes >> 2) & 1, exponent);
+                    yield return ($"BoundaryOnly{exponent}_{axes}", new Cell(0, 0, 0, exponent), neighbor, false);
+                }
+                for (int axis = 0; axis < dimensions; axis++)
+                {
+                    yield return ($"LongMaxNeighbors{exponent}_{axis}", OnAxis(axis, long.MaxValue, exponent), OnAxis(axis, long.MaxValue - 1, exponent), false);
+                    yield return ($"LongMinNeighbors{exponent}_{axis}", OnAxis(axis, long.MinValue, exponent), OnAxis(axis, long.MinValue + 1, exponent), false);
+                }
+            }
+        }
+
+        private static Cell OnAxis(int axis, long coordinate, int exponent)
+            => new Cell(axis == 0 ? coordinate : 0, axis == 1 ? coordinate : 0, axis == 2 ? coordinate : 0, exponent);
+
+        private static Cell2d Project(Cell cell) => new Cell2d(cell.X, cell.Y, cell.Exponent);
+
+        public static void CompareRandomPairs(int dimensions, int seed)
+        {
+            var random = new Random(seed);
+            for (int i = 0; i < 20000; i++)
+            {
+                var a = RandomCell(random);
+                Cell b;
+                switch (i % 4)
+                {
+                    case 0:
+                        b = RandomCell(random);
+                        break;
+                    case 1:
+                    case 2:
+                        int exponent = Math.Min(1200, a.Exponent + random.Next(131));
+                        int shift = Math.Min(63, exponent - a.Exponent);
+                        b = a.IsCenteredAtOrigin ? new Cell(exponent) :
+                            new Cell(a.X >> shift, a.Y >> shift, a.Z >> shift, exponent);
+                        if (i % 4 == 2 && !b.IsCenteredAtOrigin)
+                            b = new Cell(unchecked(b.X + 1), b.Y, b.Z, b.Exponent);
+                        break;
+                    default:
+                        a = new Cell(random.Next(-1200, 1201));
+                        b = RandomCell(random);
+                        break;
+                }
+
+                bool ac = dimensions == 2 ? Project(a).IsCenteredAtOrigin : a.IsCenteredAtOrigin;
+                bool bc = dimensions == 2 ? Project(b).IsCenteredAtOrigin : b.IsCenteredAtOrigin;
+                bool expected = AxisOverlap(a.X, a.Exponent, ac, b.X, b.Exponent, bc) &&
+                    AxisOverlap(a.Y, a.Exponent, ac, b.Y, b.Exponent, bc) &&
+                    (dimensions == 2 || AxisOverlap(a.Z, a.Exponent, ac, b.Z, b.Exponent, bc));
+                if (dimensions == 3)
+                {
+                    Assert.That(a.Intersects(b), Is.EqualTo(expected), $"{a} versus {b}");
+                    Assert.That(b.Intersects(a), Is.EqualTo(expected), $"{b} versus {a}");
+                    Assert.That(a.Intersects(a), Is.True);
+                }
+                else
+                {
+                    var a2 = Project(a);
+                    var b2 = Project(b);
+                    Assert.That(a2.Intersects(b2), Is.EqualTo(expected), $"{a2} versus {b2}");
+                    Assert.That(b2.Intersects(a2), Is.EqualTo(expected), $"{b2} versus {a2}");
+                    Assert.That(a2.Intersects(a2), Is.True);
+                }
+            }
+        }
+
+        // Independent interval oracle: use an exact common unit, form both endpoints
+        // in BigInteger (including coordinate+1 beyond Int64.MaxValue), then compare them.
+        private static bool AxisOverlap(long a, int ae, bool ac, long b, int be, bool bc)
+        {
+            int unitExponent = Math.Min(ae, be) - 1; // Random test exponents are bounded to [-1200, 1200].
+            var (aMin, aMax) = Interval(a, ae, ac, unitExponent);
+            var (bMin, bMax) = Interval(b, be, bc, unitExponent);
+            return aMin < bMax && bMin < aMax;
+        }
+
+        private static (BigInteger Min, BigInteger Max) Interval(long coordinate, int exponent, bool centered, int unitExponent)
+        {
+            if (centered)
+            {
+                var radius = BigInteger.One << (exponent - unitExponent - 1);
+                return (-radius, radius);
+            }
+            var size = BigInteger.One << (exponent - unitExponent);
+            return (coordinate * size, ((BigInteger)coordinate + 1) * size);
+        }
+
+        private static Cell RandomCell(Random random)
+        {
+            int exponent = random.Next(-1200, 1201);
+            if (random.Next(4) == 0) return new Cell(exponent);
+            long x = Coordinate(random), y = Coordinate(random), z = Coordinate(random);
+            return new Cell(x, y, z, exponent);
+        }
+
+        private static long Coordinate(Random random)
+        {
+            switch (random.Next(8))
+            {
+                case 0: return long.MinValue;
+                case 1: return long.MaxValue;
+                case 2: return (1L << 53) + random.Next(-2, 3);
+                case 3: return -(1L << 53) + random.Next(-2, 3);
+                case 4: return random.NextInt64(long.MinValue, long.MaxValue);
+                default: return random.Next(-3, 4);
+            }
+        }
+
+        public static IEnumerable<TestCaseData> InvalidCases(int dimensions)
+        {
+            var pairs = new (Cell Other, bool Expected)[]
+            {
+                (Cell.Invalid, true), (Cell.Unit, false), (new Cell(-1, -1, -1, 0), false),
+                (new Cell(0), true), (new Cell(-1073), true), (new Cell(-1074), false),
+                (new Cell(-1100), false), (new Cell(1100), true),
+                (new Cell(0, 0, 0, 1100), true), (new Cell(2, 0, 0, 1100), false),
+                (new Cell(-1, -1, -1, 1100), true),
+                (new Cell(long.MaxValue, long.MaxValue, long.MaxValue, int.MinValue), false),
+                (new Cell(long.MinValue, long.MinValue, long.MinValue, int.MinValue + 1), false)
+            };
+            for (int i = 0; i < pairs.Length; i++)
+            {
+                var (other, expected) = pairs[i];
+                yield return dimensions == 3
+                    ? new TestCaseData(other, expected).SetName("IntersectsInvalidCompatibility_" + i)
+                    : new TestCaseData(Project(other), expected).SetName("IntersectsInvalidCompatibility_" + i);
+            }
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Tests/RangesBoxes/CellTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/RangesBoxes/CellTests.cs
@@ -560,6 +560,39 @@ namespace Aardvark.Tests
 
         #endregion
 
+        #region exact intersections
+
+        private static IEnumerable<TestCaseData> ExactIntersectionCases => CellIntersectionTestData.Cases(3);
+        private static IEnumerable<TestCaseData> InvalidIntersectionCases => CellIntersectionTestData.InvalidCases(3);
+
+        [TestCaseSource(nameof(ExactIntersectionCases))]
+        public void IntersectsExactly(Cell a, Cell b, bool expected)
+        {
+            Assert.That(a.IsValid && b.IsValid, Is.True, "Exact semantics apply to valid cells");
+            Assert.That(a.Intersects(b), Is.EqualTo(expected), $"{a} versus {b}");
+            Assert.That(b.Intersects(a), Is.EqualTo(expected), "Symmetry");
+            Assert.That(a.Intersects(a), Is.True, "Self-intersection");
+            Assert.That(b.Intersects(b), Is.True, "Self-intersection");
+        }
+
+        [TestCase(7)]
+        [TestCase(31)]
+        [TestCase(2027)]
+        public void IntersectsMatchesBigIntegerIntervals(int seed)
+            => CellIntersectionTestData.CompareRandomPairs(3, seed);
+
+        [TestCaseSource(nameof(InvalidIntersectionCases))]
+        public void IntersectsPreservesInvalidCompatibility(Cell other, bool expected)
+        {
+            var invalid = Cell.Invalid;
+            bool legacy = invalid == other || invalid.BoundingBox.Intersects(other.BoundingBox);
+            Assert.That(legacy, Is.EqualTo(expected), "Characterized legacy sentinel behavior");
+            Assert.That(invalid.Intersects(other), Is.EqualTo(expected));
+            Assert.That(other.Intersects(invalid), Is.EqualTo(expected));
+        }
+
+        #endregion
+
         #region contains/intersects
 
         [Test]

--- a/tools/DocsChecker/DocsRules.cs
+++ b/tools/DocsChecker/DocsRules.cs
@@ -90,6 +90,9 @@ internal sealed class DocsRules
                 new("ai/SERIALIZATION.md", "`NetworkOrderBinaryReader` and `NetworkOrderBinaryWriter`", "Serialization docs should define network-order primitive stream semantics."),
                 new("ai/SERIALIZATION.md", "these numeric scalar and aggregate operations are allocation-free", "Serialization docs should record network-order allocation behavior."),
                 new("ai/INCREMENTAL.md", "CSharp.Data.Adaptive", "C# adaptive examples require the CSharp.Data.Adaptive namespace/package."),
+                new("ai/SEMANTICS_GEOMETRY_CORE.md", "`Cell.Intersects(Cell)` and `Cell2d.Intersects(Cell2d)`", "Geometry semantics should define exact valid-cell intersections."),
+                new("ai/SEMANTICS_GEOMETRY_CORE.md", "Face-, edge-, and corner-only contacts are excluded", "Cell intersection docs should distinguish positive-measure overlap from boundary contacts."),
+                new("ai/SEMANTICS_GEOMETRY_CORE.md", "Other Invalid-sentinel pairs retain the previous bounding-box behavior", "Cell intersection docs should preserve sentinel compatibility."),
                 new("ai/SEMANTICS_GEOMETRY_CORE.md", "`Box2f`/`Box2d` plane intersections", "Geometry semantics should cover closed, scale-invariant box/plane intersections."),
                 new("ai/SEMANTICS_GEOMETRY_CORE.md", "FastRay", "Geometry semantics should cover FastRay slab-test conventions."),
                 new("ai/SEMANTICS_GEOMETRY_CORE.md", "`Circle3f` and `Circle3d` represent a circle", "Geometry semantics should define Circle3 frame and bound conventions."),
@@ -130,6 +133,12 @@ internal sealed class DocsRules
             ],
             SourceAnchors =
             [
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell.cs", "public bool Intersects(Cell other)"),
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell.cs", "long delta = (long)Exponent - other.Exponent;"),
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell.cs", "private bool IntersectsInvalid(Cell other) => BoundingBox.Intersects(other.BoundingBox);"),
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs", "public bool Intersects(Cell2d other)"),
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs", "long delta = (long)centeredExponent - ordinary.Exponent - 1;"),
+                new("src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs", "private bool IntersectsInvalid(Cell2d other) => BoundingBox.Intersects(other.BoundingBox);"),
                 new("src/Aardvark.Base/Math/Trafos/Matrix_auto.cs", "public partial struct M44d"),
                 new("src/Aardvark.Base/Math/Trafos/Matrix_auto.cs", "public static M44d FromCols(V4d col0, V4d col1, V4d col2, V4d col3)"),
                 new("src/Aardvark.Base/Math/Trafos/Matrix_auto.cs", "public static V4d operator *(M44d m, V4d v)"),


### PR DESCRIPTION
## Summary

Replace floating-point box conversion with exact grid comparisons in Cell.Intersects and Cell2d.Intersects. This fixes missed parent/child overlaps beyond double precision and underflow, and false intersections after overflow.

- Saturate widened exponent differences, including centered/ordinary partial overlaps.
- Preserve self-intersection and Invalid compatibility; exclude boundary-only contacts.
- Leave Contains, BoundingBox, construction and hierarchy operations unchanged.
- Add 424 regression/differential cases, including 120,000 BigInteger-oracle pairs.
- Retain matched Release benchmarks: **5.2–8.6× faster** non-equal valid-cell queries, **0 B** allocated, no equality-path regression.
- Align XML/reference semantics, source anchors, drift checks and unreleased notes.

Fixes #133.