### PR TITLE
Handle degenerate vector spans without allocating coefficient solves

### DIFF
--- a/ai/SEMANTICS_GEOMETRY_CORE.md
+++ b/ai/SEMANTICS_GEOMETRY_CORE.md
@@ -14,6 +14,20 @@ For `M44d` and `Trafo3d`:
 
 Layout, multiplication side, interop conversion, and `Trafo3d` composition order are covered in `SEMANTICS_LINEAR_ALGEBRA.md`.
 
+## Linear Combinations
+
+For `V3f` and `V3d`, `IsLinearCombinationOf` treats zero bases as spanning only
+zero, and dependent nonzero bases as spanning their common line within the default
+parallelism tolerance. Coefficient queries return finite coefficients, or `false`
+with both outputs NaN. Dependent bases use the basis with the largest absolute
+component (first on ties), with the unused coefficient zero; two zero bases give
+zero coefficients for a zero target.
+
+For independent bases, the predicate tests whether `(u.Cross(v)).Dot(x)` is tiny.
+The coefficient overload instead tests whether the coefficient along `u.Cross(v)`
+is tiny. These scale-dependent tolerance checks are not interchangeable.
+All overloads are allocation-free.
+
 ## Intersection Receiver Conventions
 
 Which type carries the intersection method is fixed and not symmetric:
@@ -226,6 +240,8 @@ The closest-point and minimal-distance extensions in `SpecialPoints_auto.cs` tre
 - Attributed boolean operations have no operators.
 
 ## Source Anchors
+
+- `src/Aardvark.Base/Geometry/Relations/LinearCombination_template.cs` / `LinearCombination_auto.cs` (`LinearCombination.IsLinearCombinationOf`)
 
 - `src/Aardvark.Base/Math/RangesBoxes/Cell.cs` (`Cell.Intersects`)
 - `src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs` (`Cell2d.Intersects`)

--- a/src/Aardvark.Base/Geometry/Relations/LinearCombination_auto.cs
+++ b/src/Aardvark.Base/Geometry/Relations/LinearCombination_auto.cs
@@ -9,50 +9,85 @@ namespace Aardvark.Base
 
         #region V3f - V3f
 
+        /// <summary>
+        /// Tests membership in the span of u and v within the default tolerance.
+        /// Zero bases span only zero; dependent nonzero bases span their common line.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this V3f x, V3f u, V3f v)
         {
-            V3f n = u.Cross(v);
-            return n.IsOrthogonalTo(x);
+            var n = u.Cross(v);
+            if (!Fun.IsTiny(n.Dot(x))) return false;
+            return n != V3f.Zero || x.IsLinearCombinationOf(u.NormMax >= v.NormMax ? u : v);
         }
 
+        /// <summary>
+        /// Tests parallelism to a nonzero basis within the default tolerance.
+        /// A zero basis spans only zero.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this V3f x, V3f u)
-            => x.IsParallelTo(u);
+            => u != V3f.Zero
+                ? x.Cross(u).Norm1 < Constant<float>.PositiveTinyValue
+                : x == V3f.Zero;
 
+        /// <summary>
+        /// Finds finite coefficients reconstructing x = t0*u + t1*v within tolerance.
+        /// Dependent bases use the basis with the largest absolute component (first on ties),
+        /// with the unused coefficient zero. Zero bases succeed only for zero, with both coefficients zero.
+        /// Misses return false and set both coefficients to NaN.
+        /// For independent bases, the coefficient of u.Cross(v) must be tiny.
+        /// </summary>
         public static bool IsLinearCombinationOf(this V3f x, V3f u, V3f v, out float t0, out float t1)
         {
-            //x == t2*u + t1*v
-            V3f n = u.Cross(v);
+            var n = u.Cross(v);
+            if (n == V3f.Zero) return TryDependentCombination(x, u, v, out t0, out t1);
+            t0 = t1 = float.NaN;
 
-            float[,] mat = new float[3, 3]
+            // Scalar elimination of [u v n], with partial pivoting and the original normal-residual test.
+            var r0 = new V3f(u.X, v.X, n.X);
+            var r1 = new V3f(u.Y, v.Y, n.Y);
+            var r2 = new V3f(u.Z, v.Z, n.Z);
+            if (Fun.Abs(r1.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r1); Fun.Swap(ref x.X, ref x.Y); }
+            if (Fun.Abs(r2.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r2); Fun.Swap(ref x.X, ref x.Z); }
+
+            var f1 = r1.X / r0.X;
+            var f2 = r2.X / r0.X;
+            r1.Y -= r0.Y * f1; r1.Z -= r0.Z * f1; x.Y -= x.X * f1;
+            r2.Y -= r0.Y * f2; r2.Z -= r0.Z * f2; x.Z -= x.X * f2;
+            if (Fun.Abs(r2.Y) > Fun.Abs(r1.Y)) { Fun.Swap(ref r1, ref r2); Fun.Swap(ref x.Y, ref x.Z); }
+
+            var f = r2.Y / r1.Y;
+            var normal = (x.Z - x.Y * f) / (r2.Z - r1.Z * f);
+            if (!Fun.IsTiny(normal)) return false;
+
+            var b = (x.Y - r1.Z * normal) / r1.Y;
+            var a = (x.X - r0.Y * b - r0.Z * normal) / r0.X;
+            if (!Fun.IsFinite(a) || !Fun.IsFinite(b)) return false;
+            t0 = a;
+            t1 = b;
+            return true;
+        }
+
+        private static bool TryDependentCombination(V3f x, V3f u, V3f v, out float t0, out float t1)
+        {
+            t0 = t1 = float.NaN;
+            bool useU = u.NormMax >= v.NormMax;
+            var w = useU ? u : v;
+            if (!x.IsLinearCombinationOf(w)) return false;
+            float t = 0;
+            if (w != V3f.Zero)
             {
-                {u.X,v.X,n.X},
-                {u.Y,v.Y,n.Y},
-                {u.Z,v.Z,n.Z}
-            };
-
-            float[] result = new float[3] { x.X, x.Y, x.Z };
-
-            int[] perm = mat.LuFactorize();
-            V3f t = new V3f(mat.LuSolve(perm, result));
-
-            if (Fun.IsTiny(t.Z))
-            {
-                t0 = t.X;
-                t1 = t.Y;
-
-                return true;
+                // Divide by the largest component, avoiding squared lengths and zero divisors.
+                int i = 0;
+                if (Fun.Abs(w.Y) > Fun.Abs(w.X)) i = 1;
+                if (Fun.Abs(w.Z) > Fun.Abs(w[i])) i = 2;
+                t = x[i] / w[i];
+                if (!Fun.IsFinite(t)) return false;
             }
-            else
-            {
-                t0 = float.NaN;
-                t1 = float.NaN;
-
-                return false;
-            }
-
-            //x == 
+            t0 = useU ? t : 0;
+            t1 = useU ? 0 : t;
+            return true;
         }
 
         #endregion
@@ -60,50 +95,85 @@ namespace Aardvark.Base
 
         #region V3d - V3d
 
+        /// <summary>
+        /// Tests membership in the span of u and v within the default tolerance.
+        /// Zero bases span only zero; dependent nonzero bases span their common line.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this V3d x, V3d u, V3d v)
         {
-            V3d n = u.Cross(v);
-            return n.IsOrthogonalTo(x);
+            var n = u.Cross(v);
+            if (!Fun.IsTiny(n.Dot(x))) return false;
+            return n != V3d.Zero || x.IsLinearCombinationOf(u.NormMax >= v.NormMax ? u : v);
         }
 
+        /// <summary>
+        /// Tests parallelism to a nonzero basis within the default tolerance.
+        /// A zero basis spans only zero.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this V3d x, V3d u)
-            => x.IsParallelTo(u);
+            => u != V3d.Zero
+                ? x.Cross(u).Norm1 < Constant<double>.PositiveTinyValue
+                : x == V3d.Zero;
 
+        /// <summary>
+        /// Finds finite coefficients reconstructing x = t0*u + t1*v within tolerance.
+        /// Dependent bases use the basis with the largest absolute component (first on ties),
+        /// with the unused coefficient zero. Zero bases succeed only for zero, with both coefficients zero.
+        /// Misses return false and set both coefficients to NaN.
+        /// For independent bases, the coefficient of u.Cross(v) must be tiny.
+        /// </summary>
         public static bool IsLinearCombinationOf(this V3d x, V3d u, V3d v, out double t0, out double t1)
         {
-            //x == t2*u + t1*v
-            V3d n = u.Cross(v);
+            var n = u.Cross(v);
+            if (n == V3d.Zero) return TryDependentCombination(x, u, v, out t0, out t1);
+            t0 = t1 = double.NaN;
 
-            double[,] mat = new double[3, 3]
+            // Scalar elimination of [u v n], with partial pivoting and the original normal-residual test.
+            var r0 = new V3d(u.X, v.X, n.X);
+            var r1 = new V3d(u.Y, v.Y, n.Y);
+            var r2 = new V3d(u.Z, v.Z, n.Z);
+            if (Fun.Abs(r1.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r1); Fun.Swap(ref x.X, ref x.Y); }
+            if (Fun.Abs(r2.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r2); Fun.Swap(ref x.X, ref x.Z); }
+
+            var f1 = r1.X / r0.X;
+            var f2 = r2.X / r0.X;
+            r1.Y -= r0.Y * f1; r1.Z -= r0.Z * f1; x.Y -= x.X * f1;
+            r2.Y -= r0.Y * f2; r2.Z -= r0.Z * f2; x.Z -= x.X * f2;
+            if (Fun.Abs(r2.Y) > Fun.Abs(r1.Y)) { Fun.Swap(ref r1, ref r2); Fun.Swap(ref x.Y, ref x.Z); }
+
+            var f = r2.Y / r1.Y;
+            var normal = (x.Z - x.Y * f) / (r2.Z - r1.Z * f);
+            if (!Fun.IsTiny(normal)) return false;
+
+            var b = (x.Y - r1.Z * normal) / r1.Y;
+            var a = (x.X - r0.Y * b - r0.Z * normal) / r0.X;
+            if (!Fun.IsFinite(a) || !Fun.IsFinite(b)) return false;
+            t0 = a;
+            t1 = b;
+            return true;
+        }
+
+        private static bool TryDependentCombination(V3d x, V3d u, V3d v, out double t0, out double t1)
+        {
+            t0 = t1 = double.NaN;
+            bool useU = u.NormMax >= v.NormMax;
+            var w = useU ? u : v;
+            if (!x.IsLinearCombinationOf(w)) return false;
+            double t = 0;
+            if (w != V3d.Zero)
             {
-                {u.X,v.X,n.X},
-                {u.Y,v.Y,n.Y},
-                {u.Z,v.Z,n.Z}
-            };
-
-            double[] result = new double[3] { x.X, x.Y, x.Z };
-
-            int[] perm = mat.LuFactorize();
-            V3d t = new V3d(mat.LuSolve(perm, result));
-
-            if (Fun.IsTiny(t.Z))
-            {
-                t0 = t.X;
-                t1 = t.Y;
-
-                return true;
+                // Divide by the largest component, avoiding squared lengths and zero divisors.
+                int i = 0;
+                if (Fun.Abs(w.Y) > Fun.Abs(w.X)) i = 1;
+                if (Fun.Abs(w.Z) > Fun.Abs(w[i])) i = 2;
+                t = x[i] / w[i];
+                if (!Fun.IsFinite(t)) return false;
             }
-            else
-            {
-                t0 = double.NaN;
-                t1 = double.NaN;
-
-                return false;
-            }
-
-            //x == 
+            t0 = useU ? t : 0;
+            t1 = useU ? 0 : t;
+            return true;
         }
 
         #endregion

--- a/src/Aardvark.Base/Geometry/Relations/LinearCombination_template.cs
+++ b/src/Aardvark.Base/Geometry/Relations/LinearCombination_template.cs
@@ -1,4 +1,4 @@
-﻿using System.Runtime.CompilerServices;
+using System.Runtime.CompilerServices;
 
 namespace Aardvark.Base
 {
@@ -8,57 +8,89 @@ namespace Aardvark.Base
 
         //# foreach (var isDouble in new[] { false, true }) {
         //#   var ftype = isDouble ? "double" : "float";
-        //#   var tc = isDouble ? "d" : "f";
-        //#   var v2t = "V2" + tc;
-        //#   var v3t = "V3" + tc;
-        //#   var half = isDouble ? "0.5" : "0.5f";
+        //#   var v3t = "V3" + (isDouble ? "d" : "f");
 
         #region __v3t__ - __v3t__
 
+        /// <summary>
+        /// Tests membership in the span of u and v within the default tolerance.
+        /// Zero bases span only zero; dependent nonzero bases span their common line.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this __v3t__ x, __v3t__ u, __v3t__ v)
         {
-            __v3t__ n = u.Cross(v);
-            return n.IsOrthogonalTo(x);
+            var n = u.Cross(v);
+            if (!Fun.IsTiny(n.Dot(x))) return false;
+            return n != __v3t__.Zero || x.IsLinearCombinationOf(u.NormMax >= v.NormMax ? u : v);
         }
 
+        /// <summary>
+        /// Tests parallelism to a nonzero basis within the default tolerance.
+        /// A zero basis spans only zero.
+        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsLinearCombinationOf(this __v3t__ x, __v3t__ u)
-            => x.IsParallelTo(u);
+            => u != __v3t__.Zero
+                ? x.Cross(u).Norm1 < Constant<__ftype__>.PositiveTinyValue
+                : x == __v3t__.Zero;
 
+        /// <summary>
+        /// Finds finite coefficients reconstructing x = t0*u + t1*v within tolerance.
+        /// Dependent bases use the basis with the largest absolute component (first on ties),
+        /// with the unused coefficient zero. Zero bases succeed only for zero, with both coefficients zero.
+        /// Misses return false and set both coefficients to NaN.
+        /// For independent bases, the coefficient of u.Cross(v) must be tiny.
+        /// </summary>
         public static bool IsLinearCombinationOf(this __v3t__ x, __v3t__ u, __v3t__ v, out __ftype__ t0, out __ftype__ t1)
         {
-            //x == t2*u + t1*v
-            __v3t__ n = u.Cross(v);
+            var n = u.Cross(v);
+            if (n == __v3t__.Zero) return TryDependentCombination(x, u, v, out t0, out t1);
+            t0 = t1 = __ftype__.NaN;
 
-            __ftype__[,] mat = new __ftype__[3, 3]
+            // Scalar elimination of [u v n], with partial pivoting and the original normal-residual test.
+            var r0 = new __v3t__(u.X, v.X, n.X);
+            var r1 = new __v3t__(u.Y, v.Y, n.Y);
+            var r2 = new __v3t__(u.Z, v.Z, n.Z);
+            if (Fun.Abs(r1.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r1); Fun.Swap(ref x.X, ref x.Y); }
+            if (Fun.Abs(r2.X) > Fun.Abs(r0.X)) { Fun.Swap(ref r0, ref r2); Fun.Swap(ref x.X, ref x.Z); }
+
+            var f1 = r1.X / r0.X;
+            var f2 = r2.X / r0.X;
+            r1.Y -= r0.Y * f1; r1.Z -= r0.Z * f1; x.Y -= x.X * f1;
+            r2.Y -= r0.Y * f2; r2.Z -= r0.Z * f2; x.Z -= x.X * f2;
+            if (Fun.Abs(r2.Y) > Fun.Abs(r1.Y)) { Fun.Swap(ref r1, ref r2); Fun.Swap(ref x.Y, ref x.Z); }
+
+            var f = r2.Y / r1.Y;
+            var normal = (x.Z - x.Y * f) / (r2.Z - r1.Z * f);
+            if (!Fun.IsTiny(normal)) return false;
+
+            var b = (x.Y - r1.Z * normal) / r1.Y;
+            var a = (x.X - r0.Y * b - r0.Z * normal) / r0.X;
+            if (!Fun.IsFinite(a) || !Fun.IsFinite(b)) return false;
+            t0 = a;
+            t1 = b;
+            return true;
+        }
+
+        private static bool TryDependentCombination(__v3t__ x, __v3t__ u, __v3t__ v, out __ftype__ t0, out __ftype__ t1)
+        {
+            t0 = t1 = __ftype__.NaN;
+            bool useU = u.NormMax >= v.NormMax;
+            var w = useU ? u : v;
+            if (!x.IsLinearCombinationOf(w)) return false;
+            __ftype__ t = 0;
+            if (w != __v3t__.Zero)
             {
-                {u.X,v.X,n.X},
-                {u.Y,v.Y,n.Y},
-                {u.Z,v.Z,n.Z}
-            };
-
-            __ftype__[] result = new __ftype__[3] { x.X, x.Y, x.Z };
-
-            int[] perm = mat.LuFactorize();
-            __v3t__ t = new __v3t__(mat.LuSolve(perm, result));
-
-            if (Fun.IsTiny(t.Z))
-            {
-                t0 = t.X;
-                t1 = t.Y;
-
-                return true;
+                // Divide by the largest component, avoiding squared lengths and zero divisors.
+                int i = 0;
+                if (Fun.Abs(w.Y) > Fun.Abs(w.X)) i = 1;
+                if (Fun.Abs(w.Z) > Fun.Abs(w[i])) i = 2;
+                t = x[i] / w[i];
+                if (!Fun.IsFinite(t)) return false;
             }
-            else
-            {
-                t0 = __ftype__.NaN;
-                t1 = __ftype__.NaN;
-
-                return false;
-            }
-
-            //x == 
+            t0 = useU ? t : 0;
+            t1 = useU ? 0 : t;
+            return true;
         }
 
         #endregion

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/LinearCombinationBenchmark.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/LinearCombinationBenchmark.cs
@@ -1,0 +1,190 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Aardvark.Base.Benchmarks.Geometry
+{
+    // dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- --filter '*LinearCombinationBenchmark*'
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    public class LinearCombinationBenchmark
+    {
+        private const int Count = 256;
+        private V3d[] _x, _single, _u, _v;
+        private V3f[] _xf, _singlef, _uf, _vf;
+
+        [Params("Hit", "Miss", "Dependent")]
+        public string Case { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _x = new V3d[Count]; _single = new V3d[Count]; _u = new V3d[Count]; _v = new V3d[Count];
+            _xf = new V3f[Count]; _singlef = new V3f[Count]; _uf = new V3f[Count]; _vf = new V3f[Count];
+            for (int i = 0; i < Count; i++)
+            {
+                var u = new V3d(1 + i % 7, 2, 1);
+                var v = new V3d(0, 1 + i % 7, 3);
+                bool hit = Case == "Hit";
+                if (Case == "Dependent")
+                {
+                    (u, v) = (i % 6) switch
+                    {
+                        0 => (u, 2 * u),
+                        1 => (u, u),
+                        2 => (u, -3 * u),
+                        3 => (V3d.Zero, u),
+                        4 => (u, V3d.Zero),
+                        _ => (V3d.Zero, V3d.Zero)
+                    };
+                    hit = i / 6 % 2 == 0;
+                }
+                _u[i] = u; _v[i] = v;
+                _x[i] = hit ? 2 * u - 3 * v : Case == "Dependent" ? V3d.ZAxis : 2 * u - 3 * v + u.Cross(v);
+                _single[i] = hit ? 2 * u : V3d.ZAxis;
+                _uf[i] = (V3f)u; _vf[i] = (V3f)v; _xf[i] = (V3f)_x[i]; _singlef[i] = (V3f)_single[i];
+            }
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("DoubleSingle")]
+        public int PreviousDoubleSingle()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (Previous(_single[i], _u[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("DoubleSingle")]
+        public int ScalarDoubleSingle()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (_single[i].IsLinearCombinationOf(_u[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("DoublePair")]
+        public int PreviousDoublePair()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (Previous(_x[i], _u[i], _v[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("DoublePair")]
+        public int ScalarDoublePair()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (_x[i].IsLinearCombinationOf(_u[i], _v[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("DoubleCoefficients")]
+        public double PreviousDoubleCoefficients()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++)
+                try { if (Previous(_x[i], _u[i], _v[i], out var a, out var b)) sum += a + b; }
+                catch (ArgumentException) { sum--; }
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("DoubleCoefficients")]
+        public double ScalarDoubleCoefficients()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++)
+                try { if (_x[i].IsLinearCombinationOf(_u[i], _v[i], out var a, out var b)) sum += a + b; }
+                catch (ArgumentException) { sum--; }
+            return sum;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("FloatSingle")]
+        public int PreviousFloatSingle()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (Previous(_singlef[i], _uf[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("FloatSingle")]
+        public int ScalarFloatSingle()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (_singlef[i].IsLinearCombinationOf(_uf[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("FloatPair")]
+        public int PreviousFloatPair()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (Previous(_xf[i], _uf[i], _vf[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("FloatPair")]
+        public int ScalarFloatPair()
+        {
+            int hits = 0;
+            for (int i = 0; i < Count; i++) if (_xf[i].IsLinearCombinationOf(_uf[i], _vf[i])) hits++;
+            return hits;
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("FloatCoefficients")]
+        public float PreviousFloatCoefficients()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++)
+                try { if (Previous(_xf[i], _uf[i], _vf[i], out var a, out var b)) sum += a + b; }
+                catch (ArgumentException) { sum--; }
+            return sum;
+        }
+
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("FloatCoefficients")]
+        public float ScalarFloatCoefficients()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++)
+                try { if (_xf[i].IsLinearCombinationOf(_uf[i], _vf[i], out var a, out var b)) sum += a + b; }
+                catch (ArgumentException) { sum--; }
+            return sum;
+        }
+
+        // Method bodies at eaa8f342. Exception handling belongs to both timing adapters,
+        // not to the baseline: dependent coefficient queries originally throw.
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Previous(V3d x, V3d u) => x.IsParallelTo(u);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Previous(V3f x, V3f u) => x.IsParallelTo(u);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Previous(V3d x, V3d u, V3d v) => u.Cross(v).IsOrthogonalTo(x);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static bool Previous(V3f x, V3f u, V3f v) => u.Cross(v).IsOrthogonalTo(x);
+
+        private static bool Previous(V3d x, V3d u, V3d v, out double a, out double b)
+        {
+            var n = u.Cross(v);
+            var mat = new[,] { { u.X, v.X, n.X }, { u.Y, v.Y, n.Y }, { u.Z, v.Z, n.Z } };
+            var rhs = new[] { x.X, x.Y, x.Z };
+            var perm = mat.LuFactorize();
+            var t = new V3d(mat.LuSolve(perm, rhs));
+            if (Fun.IsTiny(t.Z)) { a = t.X; b = t.Y; return true; }
+            a = b = double.NaN;
+            return false;
+        }
+
+        private static bool Previous(V3f x, V3f u, V3f v, out float a, out float b)
+        {
+            var n = u.Cross(v);
+            var mat = new[,] { { u.X, v.X, n.X }, { u.Y, v.Y, n.Y }, { u.Z, v.Z, n.Z } };
+            var rhs = new[] { x.X, x.Y, x.Z };
+            var perm = mat.LuFactorize();
+            var t = new V3f(mat.LuSolve(perm, rhs));
+            if (Fun.IsTiny(t.Z)) { a = t.X; b = t.Y; return true; }
+            a = b = float.NaN;
+            return false;
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/LinearCombinationBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/LinearCombinationBenchmark.md
@@ -1,0 +1,61 @@
+# Linear-combination benchmarks
+
+Tracking: [#135](https://github.com/aardvark-platform/aardvark.base/issues/135).
+
+**Acceptance is blocked by predicate regressions.** Coefficient improvements do
+not offset regressions in independently used predicates.
+
+```sh
+dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
+  --filter '*LinearCombinationBenchmark*' \
+  --warmupCount 8 --iterationCount 20 --iterationTime 1000 --buildTimeout 600
+```
+
+The baseline copies the method bodies at `eaa8f342`. Each invocation processes
+256 identical prebuilt inputs; setup is outside timing. Both precisions cover
+ordinary hits, ordinary misses, and dependent bases (parallel, repeated,
+antiparallel, one zero, both zero; alternating hits and misses). Single-basis
+queries use corresponding line targets rather than two-basis plane targets.
+Both coefficient timing adapters catch `ArgumentException`: the old dependent
+queries throw, while the revised queries return a result. The old dependent
+predicates also give incorrect answers. Those rows are retained, but are not
+comparisons between two correct implementations.
+
+## Isolated Release results
+
+.NET 8.0.26; separate BenchmarkDotNet processes with the same processor affinity,
+eight warmup iterations and twenty one-second target iterations. Latency is the
+arithmetic mean per query. Throughput is `1000 / mean_ns` in millions of queries
+per second, not an average of individual sample reciprocals. Managed allocations
+are measured separately by MemoryDiagnoser and reported per query.
+
+| Operation | Case | Before ns | After ns | Before Mquery/s | After Mquery/s | Before B | After B |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Double coefficients | Dependent | 6706.316 | 7.644 | 0.149 | 130.822 | 432 | 0 |
+| Double coefficients | Hit | 101.110 | 9.391 | 9.890 | 106.485 | 248 | 0 |
+| Double coefficients | Miss | 95.966 | 5.302 | 10.420 | 188.608 | 248 | 0 |
+| Double pair | Dependent | 2.021 | 5.587 | 494.805 | 178.987 | 0 | 0 |
+| Double pair | Hit | 2.009 | 2.310 | 497.760 | 432.900 | 0 | 0 |
+| Double pair | Miss | 1.958 | 2.022 | 510.725 | 494.560 | 0 | 0 |
+| Double single | Dependent | 1.813 | 2.161 | 551.572 | 462.749 | 0 | 0 |
+| Double single | Hit | 1.736 | 2.028 | 576.037 | 493.097 | 0 | 0 |
+| Double single | Miss | 1.691 | 1.943 | 591.366 | 514.668 | 0 | 0 |
+| Float coefficients | Dependent | 8252.234 | 7.307 | 0.121 | 136.855 | 728 | 0 |
+| Float coefficients | Hit | 88.034 | 11.116 | 11.359 | 89.960 | 200 | 0 |
+| Float coefficients | Miss | 98.288 | 7.891 | 10.174 | 126.727 | 200 | 0 |
+| Float pair | Dependent | 2.009 | 5.886 | 497.760 | 169.895 | 0 | 0 |
+| Float pair | Hit | 2.014 | 2.251 | 496.524 | 444.247 | 0 | 0 |
+| Float pair | Miss | 1.930 | 2.007 | 518.135 | 498.256 | 0 | 0 |
+| Float single | Dependent | 1.825 | 2.216 | 547.945 | 451.264 | 0 | 0 |
+| Float single | Hit | 1.806 | 2.021 | 553.710 | 494.805 | 0 | 0 |
+| Float single | Miss | 1.765 | 2.002 | 566.572 | 499.500 | 0 | 0 |
+
+For ordinary two-basis hits, the 99.9% confidence half-widths are 0.0369 / 0.0385 ns
+before/after for double, and 0.0445 / 0.0953 ns for float. The latency increases are
+not dismissed as noise. Ordinary single-basis predicates also regress.
+
+BenchmarkDotNet flagged multimodality in two double coefficient measurements;
+this is diagnostic evidence, not a warning-free performance acceptance run.
+An earlier in-process prototype also regressed on predicates. It is not used to
+override these isolated measurements. No benchmark inputs or tolerance rules
+were weakened to obtain better results.

--- a/src/Tests/Aardvark.Base.Tests/Geometry/LinearCombinationTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/Geometry/LinearCombinationTests.cs
@@ -1,0 +1,271 @@
+using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Aardvark.Tests.Geometry
+{
+    [TestFixture]
+    public class LinearCombinationTests
+    {
+        private static IEnumerable<TestCaseData> SpanCases
+        {
+            get
+            {
+                yield return Case("IndependentHit", new V3d(2, -3, 0), V3d.XAxis, V3d.YAxis, true);
+                yield return Case("IndependentMiss", V3d.ZAxis, V3d.XAxis, V3d.YAxis, false);
+                yield return Case("ZeroTarget", V3d.Zero, new V3d(1, 2, 3), new V3d(3, -2, 1), true);
+                yield return Case("ParallelHit", new V3d(3, 6, 9), new V3d(1, 2, 3), new V3d(2, 4, 6), true);
+                yield return Case("ParallelMiss", V3d.XAxis, new V3d(1, 2, 3), new V3d(2, 4, 6), false);
+                yield return Case("Antiparallel", new V3d(3, 6, 9), new V3d(1, 2, 3), new V3d(-2, -4, -6), true);
+                yield return Case("Repeated", new V3d(-2, -4, -6), new V3d(1, 2, 3), new V3d(1, 2, 3), true);
+                yield return Case("OneZeroHit", new V3d(0, -6, 0), V3d.Zero, new V3d(0, 2, 0), true);
+                yield return Case("OneZeroMiss", V3d.XAxis, V3d.Zero, V3d.YAxis, false);
+                yield return Case("BothZeroHit", V3d.Zero, V3d.Zero, V3d.Zero, true);
+                yield return Case("BothZeroMiss", V3d.One, V3d.Zero, V3d.Zero, false);
+                yield return Case("SmallNonzeroTarget", new V3d(1e-20, 0, 0), V3d.Zero, V3d.Zero, false);
+            }
+        }
+
+        private static TestCaseData Case(string name, V3d x, V3d u, V3d v, bool hit)
+            => new TestCaseData(x, u, v, hit).SetName("LinearCombination_" + name);
+
+        [TestCaseSource(nameof(SpanCases))]
+        public void RanksAndBasisOrder(V3d x, V3d u, V3d v, bool hit)
+        {
+            Check(x, u, v, hit);
+            Check(x, v, u, hit);
+        }
+
+        [Test]
+        public void ExhaustiveIntegerSpans()
+        {
+            var vectors = new List<V3d>();
+            for (int x = -1; x <= 1; x++)
+                for (int y = -1; y <= 1; y++)
+                    for (int z = -1; z <= 1; z++) vectors.Add(new V3d(x, y, z));
+            int count = 0;
+            foreach (var u in vectors)
+                foreach (var v in vectors)
+                {
+                    int rank = Rank(u, v);
+                    foreach (var x in vectors)
+                    {
+                        Check(x, u, v, Rank(u, v, x) == rank);
+                        count++;
+                    }
+                }
+            Assert.That(count, Is.EqualTo(19683));
+        }
+
+        [Test]
+        public void ExhaustiveSingleIntegerSpans()
+        {
+            for (int i = 0; i < 27; i++)
+                for (int j = 0; j < 27; j++)
+                {
+                    var u = new V3d(i % 3 - 1, i / 3 % 3 - 1, i / 9 - 1);
+                    var x = new V3d(j % 3 - 1, j / 3 % 3 - 1, j / 9 - 1);
+                    bool expected = Rank(u, x) == Rank(u);
+                    Assert.That(x.IsLinearCombinationOf(u), Is.EqualTo(expected));
+                    Assert.That(((V3f)x).IsLinearCombinationOf((V3f)u), Is.EqualTo(expected));
+                }
+        }
+
+        // Exact, fraction-free row elimination: independent of vector cross/dot and library LU.
+        private static int Rank(params V3d[] columns)
+        {
+            var a = new BigInteger[3, columns.Length];
+            for (int j = 0; j < columns.Length; j++)
+                for (int i = 0; i < 3; i++) a[i, j] = (int)columns[j][i];
+            int rank = 0;
+            for (int j = 0; j < columns.Length && rank < 3; j++)
+            {
+                int pivot = rank;
+                while (pivot < 3 && a[pivot, j].IsZero) pivot++;
+                if (pivot == 3) continue;
+                for (int k = j; k < columns.Length; k++)
+                    (a[rank, k], a[pivot, k]) = (a[pivot, k], a[rank, k]);
+                for (int i = rank + 1; i < 3; i++)
+                {
+                    var factor = a[i, j];
+                    for (int k = j; k < columns.Length; k++)
+                        a[i, k] = a[i, k] * a[rank, j] - a[rank, k] * factor;
+                }
+                rank++;
+            }
+            return rank;
+        }
+
+        private static void Check(V3d x, V3d u, V3d v, bool expected)
+        {
+            string context = $"x={x}, u={u}, v={v}";
+            Assert.That(x.IsLinearCombinationOf(u, v), Is.EqualTo(expected), context);
+            Assert.That(x.IsLinearCombinationOf(u, v, out var a, out var b), Is.EqualTo(expected), context);
+            var xf = (V3f)x; var uf = (V3f)u; var vf = (V3f)v;
+            Assert.That(xf.IsLinearCombinationOf(uf, vf), Is.EqualTo(expected), context);
+            Assert.That(xf.IsLinearCombinationOf(uf, vf, out var af, out var bf), Is.EqualTo(expected), context);
+            if (expected)
+            {
+                Assert.That(double.IsFinite(a) && double.IsFinite(b), Is.True, context);
+                Assert.That(float.IsFinite(af) && float.IsFinite(bf), Is.True, context);
+                Assert.That((a * u + b * v - x).NormMax, Is.LessThanOrEqualTo(1e-12), context);
+                Assert.That((af * uf + bf * vf - xf).NormMax, Is.LessThanOrEqualTo(2e-5f), context);
+                x.IsLinearCombinationOf(u, v, out var againA, out var againB);
+                Assert.That((againA, againB), Is.EqualTo((a, b)), "Deterministic coefficients");
+                if (u.Cross(v) == V3d.Zero)
+                {
+                    Assert.That(a == 0 || b == 0, Is.True, context);
+                    Assert.That(af == 0 || bf == 0, Is.True, context);
+                }
+            }
+            else
+            {
+                Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True, context);
+                Assert.That(float.IsNaN(af) && float.IsNaN(bf), Is.True, context);
+            }
+        }
+
+        [Test]
+        public void RankOneUsesLargestBasisAndFirstOnTies()
+        {
+            var u = new V3d(1, -2, 3);
+            Assert.That((6 * u).IsLinearCombinationOf(u, -2 * u, out var a, out var b), Is.True);
+            Assert.That((a, b), Is.EqualTo((0.0, -3.0)));
+            Assert.That((6 * u).IsLinearCombinationOf(u, u, out a, out b), Is.True);
+            Assert.That((a, b), Is.EqualTo((6.0, 0.0)));
+            var uf = (V3f)u;
+            Assert.That((6 * uf).IsLinearCombinationOf(uf, -2 * uf, out var af, out var bf), Is.True);
+            Assert.That((af, bf), Is.EqualTo((0.0f, -3.0f)));
+        }
+
+        [Test]
+        public void TinyNonzeroBasisIsNotRankZero()
+        {
+            Assert.That(V3d.XAxis.IsLinearCombinationOf(new V3d(1e-200, 0, 0), V3d.Zero, out var a, out var b), Is.True);
+            Assert.That((a, b), Is.EqualTo((1e200, 0.0)));
+            Assert.That(V3f.XAxis.IsLinearCombinationOf(new V3f(1e-20f, 0, 0), V3f.Zero, out var af, out var bf), Is.True);
+            Assert.That(af, Is.EqualTo(1e20f));
+            Assert.That(bf, Is.Zero);
+        }
+
+        [Test]
+        public void NonFiniteCoefficientsAreMisses()
+        {
+            Assert.That(V3d.XAxis.IsLinearCombinationOf(new V3d(double.Epsilon, 0, 0), V3d.Zero, out var a, out var b), Is.False);
+            Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True);
+            Assert.That(V3f.XAxis.IsLinearCombinationOf(new V3f(float.Epsilon, 0, 0), V3f.Zero, out var af, out var bf), Is.False);
+            Assert.That(float.IsNaN(af) && float.IsNaN(bf), Is.True);
+        }
+
+        [Test]
+        public void NearDependentNonzeroNormalsRetainRankTwo()
+        {
+            foreach (double h in new[] { 1e-7, 1e-10, 1e-17 })
+            {
+                var u = V3d.XAxis; var v = new V3d(1, h, 0); var x = new V3d(0, h, 0);
+                Assert.That(x.IsLinearCombinationOf(u, v, out var a, out var b), Is.True);
+                Assert.That((a, b), Is.EqualTo((-1.0, 1.0)));
+                Assert.That((a * u + b * v - x).NormMax, Is.Zero);
+                var uf = (V3f)u; var vf = (V3f)v; var xf = (V3f)x;
+                Assert.That(xf.IsLinearCombinationOf(uf, vf, out var af, out var bf), Is.True);
+                Assert.That((af, bf), Is.EqualTo((-1.0f, 1.0f)));
+                Assert.That(V3d.ZAxis.IsLinearCombinationOf(u, v, out a, out b), Is.False);
+                Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True);
+                Assert.That(V3f.ZAxis.IsLinearCombinationOf(uf, vf, out af, out bf), Is.False);
+                Assert.That(float.IsNaN(af) && float.IsNaN(bf), Is.True);
+            }
+        }
+
+        [Test]
+        public void PredicateAndNormalCoefficientTolerancesArePreserved()
+        {
+            double eps = Constant<double>.PositiveTinyValue;
+            float epsf = Constant<float>.PositiveTinyValue;
+            foreach (double scale in new[] { 0.25, 1.0, 4.0 })
+                foreach (double multiplier in new[] { -2.0, -1.0, -0.5, 0.0, 0.5, 1.0, 2.0 })
+                {
+                    var u = new V3d(scale, 0, 0); var v = V3d.YAxis;
+                    var x = new V3d(2 * scale, 3, eps * multiplier);
+                    Assert.That(x.IsLinearCombinationOf(u, v), Is.EqualTo(u.Cross(v).IsOrthogonalTo(x)));
+                    Assert.That(x.IsLinearCombinationOf(u, v, out var a, out var b), Is.EqualTo(Fun.IsTiny(x.Z / scale)));
+                    if (double.IsFinite(a)) Assert.That((a, b), Is.EqualTo((2.0, 3.0)));
+                    else Assert.That(double.IsNaN(a) && double.IsNaN(b), Is.True);
+                    var lineTarget = new V3d(2 * scale, eps * multiplier, 0);
+                    Assert.That(lineTarget.IsLinearCombinationOf(u), Is.EqualTo(lineTarget.IsParallelTo(u)));
+                    Assert.That(lineTarget.IsLinearCombinationOf(u, 2 * u), Is.EqualTo(lineTarget.IsParallelTo(2 * u)));
+                    var uf = (V3f)u; var vf = (V3f)v;
+                    var xf = new V3f(2 * (float)scale, 3, epsf * (float)multiplier);
+                    Assert.That(xf.IsLinearCombinationOf(uf, vf), Is.EqualTo(uf.Cross(vf).IsOrthogonalTo(xf)));
+                    Assert.That(xf.IsLinearCombinationOf(uf, vf, out var af, out var bf), Is.EqualTo(Fun.IsTiny(xf.Z / (float)scale)));
+                    if (float.IsFinite(af)) Assert.That((af, bf), Is.EqualTo((2.0f, 3.0f)));
+                    else Assert.That(float.IsNaN(af) && float.IsNaN(bf), Is.True);
+                    var lineTargetf = new V3f(2 * (float)scale, epsf * (float)multiplier, 0);
+                    Assert.That(lineTargetf.IsLinearCombinationOf(uf), Is.EqualTo(lineTargetf.IsParallelTo(uf)));
+                    Assert.That(lineTargetf.IsLinearCombinationOf(uf, 2 * uf), Is.EqualTo(lineTargetf.IsParallelTo(2 * uf)));
+                }
+        }
+
+        [Test]
+        public void OrdinaryCoefficientsMatchPreviousSolve()
+        {
+            var random = new Random(731);
+            for (int i = 0; i < 1000; i++)
+            {
+                var u = new V3d(random.Next(-8, 9), random.Next(-8, 9), random.Next(-8, 9));
+                var v = new V3d(random.Next(-8, 9), random.Next(-8, 9), random.Next(-8, 9));
+                var n = u.Cross(v);
+                if (n == V3d.Zero) continue;
+                var x = 2 * u - 3 * v;
+                var mat = new[,] { { u.X, v.X, n.X }, { u.Y, v.Y, n.Y }, { u.Z, v.Z, n.Z } };
+                var t = mat.LuSolve(mat.LuFactorize(), new[] { x.X, x.Y, x.Z });
+                bool hit = x.IsLinearCombinationOf(u, v, out var a, out var b);
+                Assert.That(hit, Is.EqualTo(Fun.IsTiny(t[2])));
+                if (hit)
+                {
+                    Assert.That(a, Is.EqualTo(t[0]).Within(2e-13));
+                    Assert.That(b, Is.EqualTo(t[1]).Within(2e-13));
+                }
+                var uf = (V3f)u; var vf = (V3f)v; var nf = uf.Cross(vf); var xf = (V3f)x;
+                var matf = new[,] { { uf.X, vf.X, nf.X }, { uf.Y, vf.Y, nf.Y }, { uf.Z, vf.Z, nf.Z } };
+                var tf = matf.LuSolve(matf.LuFactorize(), new[] { xf.X, xf.Y, xf.Z });
+                bool hitf = xf.IsLinearCombinationOf(uf, vf, out var af, out var bf);
+                Assert.That(hitf, Is.EqualTo(Fun.IsTiny(tf[2])));
+                if (hitf)
+                {
+                    Assert.That(af, Is.EqualTo(tf[0]).Within(2e-5f));
+                    Assert.That(bf, Is.EqualTo(tf[1]).Within(2e-5f));
+                }
+            }
+        }
+
+        [Test]
+        public void WarmedCoefficientQueriesAllocateNothing()
+        {
+            RunQueries(20000);
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            double checksum = RunQueries(20000);
+            long bytes = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.That(checksum, Is.GreaterThan(0));
+            Assert.That(bytes, Is.Zero);
+        }
+
+        private static readonly V3d[] Bases = { V3d.Zero, V3d.XAxis, V3d.YAxis, new V3d(1, 2, 3) };
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static double RunQueries(int count)
+        {
+            double checksum = 0;
+            for (int i = 0; i < count; i++)
+            {
+                var u = Bases[i % 4]; var v = Bases[i / 4 % 4];
+                var x = i % 2 == 0 ? 2 * u + v : V3d.ZAxis;
+                if (x.IsLinearCombinationOf(u, v, out var a, out var b)) checksum += a + b + 1;
+                if (((V3f)x).IsLinearCombinationOf((V3f)u, (V3f)v, out var af, out var bf)) checksum += af + bf + 1;
+            }
+            return checksum;
+        }
+    }
+}


### PR DESCRIPTION
Refs #135.

- Correct zero/dependent-basis semantics for V3f/V3d. Return deterministic finite coefficients, or false with two NaNs instead of a singular-LU exception.
- Replace allocating LU arrays with scalar pivoted elimination, preserving the normal-residual tolerance and leaving general vector-relation/LU APIs unchanged.
- Add an independent exact-rank oracle over all 19,683 integer triples, reconstruction and allocation checks, near-degenerate coverage, and template/XML/reference alignment.

**Performance acceptance remains blocked.** Isolated ordinary double coefficient hits improve from 101.110 to 9.391 ns and 248 to 0 B, but two-basis predicate hits regress from 2.009 to 2.310 ns. Single-basis predicates also regress. Two coefficient measurements have multimodality warnings. The complete before/after latency, throughput and allocation table is retained beside the benchmark fixture.

This must remain draft and unmerged under the no-regression requirement. No release-note entry is included.