### PR TITLE
Compute scale-safe minimum triangle bounding volumes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+- [Base] Corrected and accelerated scale-safe minimum triangle bounding circles and spheres
 - [Base] Fixed `Cell.Intersects` and `Cell2d.Intersects`
 - [Base] Corrected winding- and translation-stable 2D and 3D polygon centroids
 - [Base] Corrected complex magnitude, reciprocal, division, and square roots at extreme finite scales

--- a/ai/SEMANTICS_GEOMETRY_CORE.md
+++ b/ai/SEMANTICS_GEOMETRY_CORE.md
@@ -32,6 +32,16 @@ var hit = RayHit3d.MaxRange;
 bool hitsTri = ray.Hits(triangle, 0.0, double.MaxValue, ref hit);
 ```
 
+## Triangle Bounding Volumes
+
+`Triangle2f`/`Triangle2d` bounding circles and `Triangle3f`/`Triangle3d` bounding
+spheres are smallest enclosing bounds, up to floating-point rounding. Right,
+obtuse and collinear triangles use a longest-edge diameter; coincident points
+have zero radius. Non-finite vertices return the matching `Invalid` sentinel.
+The radius accounts for the returned center's rounding so translated bounds
+still enclose their vertices. These properties are allocation-free and do not
+change the separate `CircumCircle` APIs.
+
 ## Circle3 Frame And Bounds
 
 `Circle3f` and `Circle3d` represent a circle by `Center`, a normalized `Normal`,
@@ -226,6 +236,9 @@ The closest-point and minimal-distance extensions in `SpecialPoints_auto.cs` tre
 - Attributed boolean operations have no operators.
 
 ## Source Anchors
+
+- `src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_template.cs` (`BoundingCircle2f`, `BoundingCircle2d` after generation)
+- `src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_template.cs` (`BoundingSphere3f`, `BoundingSphere3d` after generation)
 
 - `src/Aardvark.Base/Math/RangesBoxes/Cell.cs` (`Cell.Intersects`)
 - `src/Aardvark.Base/Math/RangesBoxes/Cell2d.cs` (`Cell2d.Intersects`)

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_auto.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_auto.cs
@@ -126,35 +126,91 @@ namespace Aardvark.Base
 
         #region IBoundingCircle2f Members
 
+        /// <summary>
+        /// Returns the smallest enclosing circle, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
+        /// </summary>
         public readonly Circle2f BoundingCircle2f
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = P1 - P0;
-                var edge02 = P2 - P0;
-                float dot0101 = Vec.Dot(edge01, edge01);
-                float dot0102 = Vec.Dot(edge01, edge02);
-                float dot0202 = Vec.Dot(edge02, edge02);
-                float d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= 1e-4f) return Circle2f.Invalid;
-                float s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                float t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var cir = new Circle2f();
-                if (s <= 0)
-                    cir.Center = 0.5f * (P0 + P2);
-                else if (t <= 0)
-                    cir.Center = 0.5f * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= 1e-10f && sum <= 1e10f)) return BoundingCircleScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = 0.5f * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    cir.Center = 0.5f * (P1 + P2);
-                    p = P1;
+                    var relative = useE ? e : f;
+                    var area = d.X * relative.Y - d.Y * relative.X;
+                    var t = dot / (2 * area);
+                    offset += new V2f(-d.Y * t, d.X * t);
                 }
-                else
-                    cir.Center = P0 + s * edge01 + t * edge02;
-                cir.Radius = (cir.Center - p).Length;
-                return cir;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new Circle2f(center, r2.Sqrt());
             }
+        }
+
+        private readonly Circle2f BoundingCircleScaled()
+        {
+            var p0 = (V2d)P0; var p1 = (V2d)P1; var p2 = (V2d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return Circle2f.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new Circle2f(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            var relative = useE ? e : f;
+            double area = d.X * relative.Y - d.Y * relative.X;
+            if (dot > 0 && area != 0)
+            {
+                double t = dot / (2 * area);
+                offset += new V2d(-d.Y * t, d.X * t);
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            var rounded = (V2f)center;
+            double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
+            return new Circle2f(rounded, (float)radius);
+        }
+
+        private static V2d DivideForBounds(V2d p, double scale)
+            => new V2d(p.X / scale, p.Y / scale);
+
+        private static double BoundsDistance(V2d a, V2d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion
@@ -362,35 +418,91 @@ namespace Aardvark.Base
 
         #region IBoundingCircle2d Members
 
+        /// <summary>
+        /// Returns the smallest enclosing circle, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
+        /// </summary>
         public readonly Circle2d BoundingCircle2d
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = P1 - P0;
-                var edge02 = P2 - P0;
-                double dot0101 = Vec.Dot(edge01, edge01);
-                double dot0102 = Vec.Dot(edge01, edge02);
-                double dot0202 = Vec.Dot(edge02, edge02);
-                double d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= 1e-6) return Circle2d.Invalid;
-                double s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                double t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var cir = new Circle2d();
-                if (s <= 0)
-                    cir.Center = 0.5 * (P0 + P2);
-                else if (t <= 0)
-                    cir.Center = 0.5 * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= 1e-100 && sum <= 1e100)) return BoundingCircleScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = 0.5 * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    cir.Center = 0.5 * (P1 + P2);
-                    p = P1;
+                    var relative = useE ? e : f;
+                    var area = d.X * relative.Y - d.Y * relative.X;
+                    var t = dot / (2 * area);
+                    offset += new V2d(-d.Y * t, d.X * t);
                 }
-                else
-                    cir.Center = P0 + s * edge01 + t * edge02;
-                cir.Radius = (cir.Center - p).Length;
-                return cir;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new Circle2d(center, r2.Sqrt());
             }
+        }
+
+        private readonly Circle2d BoundingCircleScaled()
+        {
+            var p0 = (V2d)P0; var p1 = (V2d)P1; var p2 = (V2d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return Circle2d.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new Circle2d(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            var relative = useE ? e : f;
+            double area = d.X * relative.Y - d.Y * relative.X;
+            if (dot > 0 && area != 0)
+            {
+                double t = dot / (2 * area);
+                offset += new V2d(-d.Y * t, d.X * t);
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            var rounded = (V2d)center;
+            double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
+            return new Circle2d(rounded, (double)radius);
+        }
+
+        private static V2d DivideForBounds(V2d p, double scale)
+            => new V2d(p.X / scale, p.Y / scale);
+
+        private static double BoundsDistance(V2d a, V2d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_auto.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_auto.cs
@@ -136,27 +136,50 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = BoundsDot(a, a); var ab = BoundsDot(a, b); var bb = BoundsDot(b, b);
+                var sum = aa + bb;
                 if (!(sum >= 1e-10f && sum <= 1e10f)) return BoundingCircleScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = 0.5f * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (BoundsDot(P0, P0) > 96 * sum) return BoundingCircleScaled();
+                if (ab <= 0) return BoundingCircleDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    var relative = useE ? e : f;
-                    var area = d.X * relative.Y - d.Y * relative.X;
-                    var t = dot / (2 * area);
-                    offset += new V2f(-d.Y * t, d.X * t);
+                    if (!(ab - aa <= 2e-6f * sum && (P0 - P1).Dot(P2 - P1) > 0))
+                        return BoundingCircleDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new Circle2f(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (!(ab - bb <= 2e-6f * sum && (P0 - P2).Dot(P1 - P2) > 0))
+                        return BoundingCircleDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= 0.1f * aa * bb)) return BoundingCircleScaled();
+                var scale = 0.5f / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new V2f(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = BoundsDot(roundedOffset, roundedOffset).Sqrt();
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new Circle2f(center, radius * 1.0000076f);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static float BoundsDot(V2f a, V2f b)
+            => Fun.MultiplyAdd(a.X, b.X, a.Y * b.Y);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Circle2f BoundingCircleDiameter(V2f origin, V2f edge)
+        {
+            var offset = 0.5f * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new Circle2f(center, BoundsDot(roundedOffset, roundedOffset).Sqrt() * 1.0000076f);
         }
 
         private readonly Circle2f BoundingCircleScaled()
@@ -198,7 +221,10 @@ namespace Aardvark.Base
             center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
             var rounded = (V2f)center;
             double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
-            return new Circle2f(rounded, (float)radius);
+            var resultRadius = (float)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new Circle2f(rounded, resultRadius);
         }
 
         private static V2d DivideForBounds(V2d p, double scale)
@@ -428,27 +454,50 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = BoundsDot(a, a); var ab = BoundsDot(a, b); var bb = BoundsDot(b, b);
+                var sum = aa + bb;
                 if (!(sum >= 1e-100 && sum <= 1e100)) return BoundingCircleScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = 0.5 * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (BoundsDot(P0, P0) > 96 * sum) return BoundingCircleScaled();
+                if (ab <= 0) return BoundingCircleDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    var relative = useE ? e : f;
-                    var area = d.X * relative.Y - d.Y * relative.X;
-                    var t = dot / (2 * area);
-                    offset += new V2d(-d.Y * t, d.X * t);
+                    if (!(ab - aa <= 4e-15 * sum && (P0 - P1).Dot(P2 - P1) > 0))
+                        return BoundingCircleDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new Circle2d(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (!(ab - bb <= 4e-15 * sum && (P0 - P2).Dot(P1 - P2) > 0))
+                        return BoundingCircleDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= 0.1 * aa * bb)) return BoundingCircleScaled();
+                var scale = 0.5 / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new V2d(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = BoundsDot(roundedOffset, roundedOffset).Sqrt();
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new Circle2d(center, radius * 1.0000000000000142);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static double BoundsDot(V2d a, V2d b)
+            => Fun.MultiplyAdd(a.X, b.X, a.Y * b.Y);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Circle2d BoundingCircleDiameter(V2d origin, V2d edge)
+        {
+            var offset = 0.5 * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new Circle2d(center, BoundsDot(roundedOffset, roundedOffset).Sqrt() * 1.0000000000000142);
         }
 
         private readonly Circle2d BoundingCircleScaled()
@@ -490,7 +539,10 @@ namespace Aardvark.Base
             center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
             var rounded = (V2d)center;
             double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
-            return new Circle2d(rounded, (double)radius);
+            var resultRadius = (double)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new Circle2d(rounded, resultRadius);
         }
 
         private static V2d DivideForBounds(V2d p, double scale)

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_template.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_template.cs
@@ -18,7 +18,8 @@ namespace Aardvark.Base
     //#   var iboundingcircle2t = "IBoundingCircle2" + tc;
     //#   var half = isDouble ? "0.5" : "0.5f";
     //#   var pi = isDouble ? "Constant.Pi" : "ConstantF.Pi";
-    //#   var eps = isDouble ? "1e-6" : "1e-4f";
+    //#   var boundsLow = isDouble ? "1e-100" : "1e-10f";
+    //#   var boundsHigh = isDouble ? "1e100" : "1e10f";
     #region __type__
 
     /// <summary>
@@ -141,35 +142,91 @@ namespace Aardvark.Base
 
         #region __iboundingcircle2t__ Members
 
+        /// <summary>
+        /// Returns the smallest enclosing circle, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
+        /// </summary>
         public readonly __circle2t__ BoundingCircle2__tc__
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = P1 - P0;
-                var edge02 = P2 - P0;
-                __ftype__ dot0101 = Vec.Dot(edge01, edge01);
-                __ftype__ dot0102 = Vec.Dot(edge01, edge02);
-                __ftype__ dot0202 = Vec.Dot(edge02, edge02);
-                __ftype__ d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= __eps__) return __circle2t__.Invalid;
-                __ftype__ s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                __ftype__ t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var cir = new __circle2t__();
-                if (s <= 0)
-                    cir.Center = __half__ * (P0 + P2);
-                else if (t <= 0)
-                    cir.Center = __half__ * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= __boundsLow__ && sum <= __boundsHigh__)) return BoundingCircleScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = __half__ * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    cir.Center = __half__ * (P1 + P2);
-                    p = P1;
+                    var relative = useE ? e : f;
+                    var area = d.X * relative.Y - d.Y * relative.X;
+                    var t = dot / (2 * area);
+                    offset += new __v2t__(-d.Y * t, d.X * t);
                 }
-                else
-                    cir.Center = P0 + s * edge01 + t * edge02;
-                cir.Radius = (cir.Center - p).Length;
-                return cir;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new __circle2t__(center, r2.Sqrt());
             }
+        }
+
+        private readonly __circle2t__ BoundingCircleScaled()
+        {
+            var p0 = (V2d)P0; var p1 = (V2d)P1; var p2 = (V2d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return __circle2t__.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new __circle2t__(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            var relative = useE ? e : f;
+            double area = d.X * relative.Y - d.Y * relative.X;
+            if (dot > 0 && area != 0)
+            {
+                double t = dot / (2 * area);
+                offset += new V2d(-d.Y * t, d.X * t);
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            var rounded = (__v2t__)center;
+            double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
+            return new __circle2t__(rounded, (__ftype__)radius);
+        }
+
+        private static V2d DivideForBounds(V2d p, double scale)
+            => new V2d(p.X / scale, p.Y / scale);
+
+        private static double BoundsDistance(V2d a, V2d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_template.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle2_template.cs
@@ -20,6 +20,9 @@ namespace Aardvark.Base
     //#   var pi = isDouble ? "Constant.Pi" : "ConstantF.Pi";
     //#   var boundsLow = isDouble ? "1e-100" : "1e-10f";
     //#   var boundsHigh = isDouble ? "1e100" : "1e10f";
+    //#   var boundsCondition = isDouble ? "0.1" : "0.1f";
+    //#   var boundsRadiusFactor = isDouble ? "1.0000000000000142" : "1.0000076f";
+    //#   var boundsAngleTolerance = isDouble ? "4e-15" : "2e-6f";
     #region __type__
 
     /// <summary>
@@ -152,27 +155,50 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = BoundsDot(a, a); var ab = BoundsDot(a, b); var bb = BoundsDot(b, b);
+                var sum = aa + bb;
                 if (!(sum >= __boundsLow__ && sum <= __boundsHigh__)) return BoundingCircleScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = __half__ * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (BoundsDot(P0, P0) > 96 * sum) return BoundingCircleScaled();
+                if (ab <= 0) return BoundingCircleDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    var relative = useE ? e : f;
-                    var area = d.X * relative.Y - d.Y * relative.X;
-                    var t = dot / (2 * area);
-                    offset += new __v2t__(-d.Y * t, d.X * t);
+                    if (!(ab - aa <= __boundsAngleTolerance__ * sum && (P0 - P1).Dot(P2 - P1) > 0))
+                        return BoundingCircleDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new __circle2t__(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (!(ab - bb <= __boundsAngleTolerance__ * sum && (P0 - P2).Dot(P1 - P2) > 0))
+                        return BoundingCircleDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= __boundsCondition__ * aa * bb)) return BoundingCircleScaled();
+                var scale = __half__ / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new __v2t__(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = BoundsDot(roundedOffset, roundedOffset).Sqrt();
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new __circle2t__(center, radius * __boundsRadiusFactor__);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static __ftype__ BoundsDot(__v2t__ a, __v2t__ b)
+            => Fun.MultiplyAdd(a.X, b.X, a.Y * b.Y);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static __circle2t__ BoundingCircleDiameter(__v2t__ origin, __v2t__ edge)
+        {
+            var offset = __half__ * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new __circle2t__(center, BoundsDot(roundedOffset, roundedOffset).Sqrt() * __boundsRadiusFactor__);
         }
 
         private readonly __circle2t__ BoundingCircleScaled()
@@ -214,7 +240,10 @@ namespace Aardvark.Base
             center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
             var rounded = (__v2t__)center;
             double radius = Fun.Max(BoundsDistance((V2d)rounded, (V2d)P0), BoundsDistance((V2d)rounded, (V2d)P1), BoundsDistance((V2d)rounded, (V2d)P2));
-            return new __circle2t__(rounded, (__ftype__)radius);
+            var resultRadius = (__ftype__)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new __circle2t__(rounded, resultRadius);
         }
 
         private static V2d DivideForBounds(V2d p, double scale)

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_auto.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_auto.cs
@@ -63,29 +63,56 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = a.LengthSquared; var ab = a.Dot(b); var bb = b.LengthSquared;
+                var sum = aa + bb;
                 if (!(sum >= 1e-10f && sum <= 1e10f)) return BoundingSphereScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = 0.5f * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (P0.LengthSquared > 96 * sum) return BoundingSphereScaled();
+                // A thin acute angle may round to right in the local dot products.
+                if (ab <= 0) return BoundingSphereDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    // The shorter leg stays at least 45 degrees from the longest-edge line.
-                    var relative = useE ? e : f;
-                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
-                    var pp = perpendicular.LengthSquared;
-                    if (pp == 0) return BoundingSphereScaled();
-                    offset += perpendicular * (dot / (2 * pp));
+                    if (ab - aa <= 2e-6f * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= 0.1f * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new Sphere3f(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (ab - bb <= 2e-6f * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= 0.1f * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= 0.1f * aa * bb)) return BoundingSphereScaled();
+                var scale = 0.5f / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new V3f(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y),
+                    Fun.MultiplyAdd(t, b.Z, s * a.Z));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = roundedOffset.Length;
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new Sphere3f(center, radius * 1.0000076f);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Sphere3f BoundingSphereDiameter(V3f origin, V3f edge)
+        {
+            var offset = 0.5f * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new Sphere3f(center, roundedOffset.Length * 1.0000076f);
         }
 
         private readonly Sphere3f BoundingSphereScaled()
@@ -134,7 +161,10 @@ namespace Aardvark.Base
             center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
             var rounded = (V3f)center;
             double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
-            return new Sphere3f(rounded, (float)radius);
+            var resultRadius = (float)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new Sphere3f(rounded, resultRadius);
         }
 
         private static V3d DivideForBounds(V3d p, double scale)
@@ -354,29 +384,56 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = a.LengthSquared; var ab = a.Dot(b); var bb = b.LengthSquared;
+                var sum = aa + bb;
                 if (!(sum >= 1e-100 && sum <= 1e100)) return BoundingSphereScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = 0.5 * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (P0.LengthSquared > 96 * sum) return BoundingSphereScaled();
+                // A thin acute angle may round to right in the local dot products.
+                if (ab <= 0) return BoundingSphereDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    // The shorter leg stays at least 45 degrees from the longest-edge line.
-                    var relative = useE ? e : f;
-                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
-                    var pp = perpendicular.LengthSquared;
-                    if (pp == 0) return BoundingSphereScaled();
-                    offset += perpendicular * (dot / (2 * pp));
+                    if (ab - aa <= 4e-15 * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= 0.1 * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new Sphere3d(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (ab - bb <= 4e-15 * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= 0.1 * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= 0.1 * aa * bb)) return BoundingSphereScaled();
+                var scale = 0.5 / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new V3d(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y),
+                    Fun.MultiplyAdd(t, b.Z, s * a.Z));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = roundedOffset.Length;
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new Sphere3d(center, radius * 1.0000000000000142);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static Sphere3d BoundingSphereDiameter(V3d origin, V3d edge)
+        {
+            var offset = 0.5 * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new Sphere3d(center, roundedOffset.Length * 1.0000000000000142);
         }
 
         private readonly Sphere3d BoundingSphereScaled()
@@ -425,7 +482,10 @@ namespace Aardvark.Base
             center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
             var rounded = (V3d)center;
             double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
-            return new Sphere3d(rounded, (double)radius);
+            var resultRadius = (double)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new Sphere3d(rounded, resultRadius);
         }
 
         private static V3d DivideForBounds(V3d p, double scale)

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_auto.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_auto.cs
@@ -54,37 +54,99 @@ namespace Aardvark.Base
         #region IBoundingSphere3f Members
 
         /// <summary>
-        /// Returns the bounding sphere of the triangle.
+        /// Returns the smallest enclosing sphere, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
         /// </summary>
         public readonly Sphere3f BoundingSphere3f
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = Edge01;
-                var edge02 = Edge02;
-                float dot0101 = Vec.Dot(edge01, edge01);
-                float dot0102 = Vec.Dot(edge01, edge02);
-                float dot0202 = Vec.Dot(edge02, edge02);
-                float d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= 1e-5f) return Sphere3f.Invalid;
-                float s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                float t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var sph = new Sphere3f();
-                if (s <= 0)
-                    sph.Center = 0.5f * (P0 + P2);
-                else if (t <= 0)
-                    sph.Center = 0.5f * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= 1e-10f && sum <= 1e10f)) return BoundingSphereScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = 0.5f * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    sph.Center = 0.5f * (P1 + P2);
-                    p = P1;
+                    // The shorter leg stays at least 45 degrees from the longest-edge line.
+                    var relative = useE ? e : f;
+                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
+                    var pp = perpendicular.LengthSquared;
+                    if (pp == 0) return BoundingSphereScaled();
+                    offset += perpendicular * (dot / (2 * pp));
                 }
-                else
-                    sph.Center = P0 + s * edge01 + t * edge02;
-                sph.Radius = (sph.Center - p).Length;
-                return sph;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new Sphere3f(center, r2.Sqrt());
             }
+        }
+
+        private readonly Sphere3f BoundingSphereScaled()
+        {
+            var p0 = (V3d)P0; var p1 = (V3d)P1; var p2 = (V3d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return Sphere3f.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new Sphere3f(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            if (dot > 0)
+            {
+                var relative = useE ? e : f;
+                var n = d.Cross(relative);
+                double nm = n.NormMax;
+                if (nm > 0)
+                {
+                    // Normalize before the second cross product, avoiding a squared tiny normal.
+                    var perpendicular = DivideForBounds(n, nm).Cross(d);
+                    double denominator = 2 * perpendicular.Dot(relative);
+                    if (denominator != 0) offset += perpendicular * (dot / denominator);
+                }
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
+            var rounded = (V3f)center;
+            double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
+            return new Sphere3f(rounded, (float)radius);
+        }
+
+        private static V3d DivideForBounds(V3d p, double scale)
+            => new V3d(p.X / scale, p.Y / scale, p.Z / scale);
+
+        private static double BoundsDistance(V3d a, V3d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion
@@ -283,37 +345,99 @@ namespace Aardvark.Base
         #region IBoundingSphere3d Members
 
         /// <summary>
-        /// Returns the bounding sphere of the triangle.
+        /// Returns the smallest enclosing sphere, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
         /// </summary>
         public readonly Sphere3d BoundingSphere3d
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = Edge01;
-                var edge02 = Edge02;
-                double dot0101 = Vec.Dot(edge01, edge01);
-                double dot0102 = Vec.Dot(edge01, edge02);
-                double dot0202 = Vec.Dot(edge02, edge02);
-                double d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= 1e-9) return Sphere3d.Invalid;
-                double s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                double t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var sph = new Sphere3d();
-                if (s <= 0)
-                    sph.Center = 0.5 * (P0 + P2);
-                else if (t <= 0)
-                    sph.Center = 0.5 * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= 1e-100 && sum <= 1e100)) return BoundingSphereScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = 0.5 * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    sph.Center = 0.5 * (P1 + P2);
-                    p = P1;
+                    // The shorter leg stays at least 45 degrees from the longest-edge line.
+                    var relative = useE ? e : f;
+                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
+                    var pp = perpendicular.LengthSquared;
+                    if (pp == 0) return BoundingSphereScaled();
+                    offset += perpendicular * (dot / (2 * pp));
                 }
-                else
-                    sph.Center = P0 + s * edge01 + t * edge02;
-                sph.Radius = (sph.Center - p).Length;
-                return sph;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new Sphere3d(center, r2.Sqrt());
             }
+        }
+
+        private readonly Sphere3d BoundingSphereScaled()
+        {
+            var p0 = (V3d)P0; var p1 = (V3d)P1; var p2 = (V3d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return Sphere3d.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new Sphere3d(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            if (dot > 0)
+            {
+                var relative = useE ? e : f;
+                var n = d.Cross(relative);
+                double nm = n.NormMax;
+                if (nm > 0)
+                {
+                    // Normalize before the second cross product, avoiding a squared tiny normal.
+                    var perpendicular = DivideForBounds(n, nm).Cross(d);
+                    double denominator = 2 * perpendicular.Dot(relative);
+                    if (denominator != 0) offset += perpendicular * (dot / denominator);
+                }
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
+            var rounded = (V3d)center;
+            double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
+            return new Sphere3d(rounded, (double)radius);
+        }
+
+        private static V3d DivideForBounds(V3d p, double scale)
+            => new V3d(p.X / scale, p.Y / scale, p.Z / scale);
+
+        private static double BoundsDistance(V3d a, V3d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_template.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_template.cs
@@ -20,6 +20,9 @@ namespace Aardvark.Base
     //#   var pi = isDouble ? "Constant.Pi" : "ConstantF.Pi";
     //#   var boundsLow = isDouble ? "1e-100" : "1e-10f";
     //#   var boundsHigh = isDouble ? "1e100" : "1e10f";
+    //#   var boundsCondition = isDouble ? "0.1" : "0.1f";
+    //#   var boundsRadiusFactor = isDouble ? "1.0000000000000142" : "1.0000076f";
+    //#   var boundsAngleTolerance = isDouble ? "4e-15" : "2e-6f";
     #region __type__
 
     /// <summary>
@@ -79,29 +82,56 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
-                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
-                var sum = aa + bb + cc;
+                var a = P1 - P0; var b = P2 - P0;
+                var aa = a.LengthSquared; var ab = a.Dot(b); var bb = b.LengthSquared;
+                var sum = aa + bb;
                 if (!(sum >= __boundsLow__ && sum <= __boundsHigh__)) return BoundingSphereScaled();
-                var origin = P0; var d = a; var e = b; var f = c;
-                bool useE = bb <= cc;
-                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
-                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
-                var offset = __half__ * d;
-                var dot = e.Dot(f);
-                if (dot > 0)
+                // Large translations need exact radius reconstruction after center rounding.
+                if (P0.LengthSquared > 96 * sum) return BoundingSphereScaled();
+                // A thin acute angle may round to right in the local dot products.
+                if (ab <= 0) return BoundingSphereDiameter(P1, b - a);
+                else if (ab >= aa)
                 {
-                    // The shorter leg stays at least 45 degrees from the longest-edge line.
-                    var relative = useE ? e : f;
-                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
-                    var pp = perpendicular.LengthSquared;
-                    if (pp == 0) return BoundingSphereScaled();
-                    offset += perpendicular * (dot / (2 * pp));
+                    if (ab - aa <= __boundsAngleTolerance__ * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= __boundsCondition__ * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, b);
                 }
-                var center = origin + offset;
-                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
-                return new __sphere3t__(center, r2.Sqrt());
+                else if (ab >= bb)
+                {
+                    if (ab - bb <= __boundsAngleTolerance__ * sum)
+                    {
+                        var ambiguousDeterminant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                        if (!(ambiguousDeterminant >= __boundsCondition__ * aa * bb)) return BoundingSphereScaled();
+                    }
+                    return BoundingSphereDiameter(P0, a);
+                }
+                var determinant = Fun.MultiplyAdd(aa, bb, -ab * ab);
+                if (!(determinant >= __boundsCondition__ * aa * bb)) return BoundingSphereScaled();
+                var scale = __half__ / determinant;
+                var s = bb * (aa - ab) * scale;
+                var t = aa * (bb - ab) * scale;
+                var offset = new __v3t__(
+                    Fun.MultiplyAdd(t, b.X, s * a.X),
+                    Fun.MultiplyAdd(t, b.Y, s * a.Y),
+                    Fun.MultiplyAdd(t, b.Z, s * a.Z));
+                var center = P0 + offset;
+                var roundedOffset = center - P0;
+                var radius = roundedOffset.Length;
+                // The conditioned solve and translation guard bound roundoff; round the radius outward.
+                return new __sphere3t__(center, radius * __boundsRadiusFactor__);
             }
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static __sphere3t__ BoundingSphereDiameter(__v3t__ origin, __v3t__ edge)
+        {
+            var offset = __half__ * edge;
+            var center = origin + offset;
+            var roundedOffset = center - origin;
+            return new __sphere3t__(center, roundedOffset.Length * __boundsRadiusFactor__);
         }
 
         private readonly __sphere3t__ BoundingSphereScaled()
@@ -150,7 +180,10 @@ namespace Aardvark.Base
             center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
             var rounded = (__v3t__)center;
             double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
-            return new __sphere3t__(rounded, (__ftype__)radius);
+            var resultRadius = (__ftype__)radius;
+            var directRadius = Fun.Max((rounded - P0).Length, (rounded - P1).Length, (rounded - P2).Length);
+            if (directRadius.IsFinite()) resultRadius = Fun.Max(resultRadius, directRadius);
+            return new __sphere3t__(rounded, resultRadius);
         }
 
         private static V3d DivideForBounds(V3d p, double scale)

--- a/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_template.cs
+++ b/src/Aardvark.Base/Geometry/Types/Triangle/Triangle3_template.cs
@@ -18,7 +18,8 @@ namespace Aardvark.Base
     //#   var iboundingsphere3t = "IBoundingSphere3" + tc;
     //#   var half = isDouble ? "0.5" : "0.5f";
     //#   var pi = isDouble ? "Constant.Pi" : "ConstantF.Pi";
-    //#   var eps = isDouble ? "1e-9" : "1e-5f";
+    //#   var boundsLow = isDouble ? "1e-100" : "1e-10f";
+    //#   var boundsHigh = isDouble ? "1e100" : "1e10f";
     #region __type__
 
     /// <summary>
@@ -69,37 +70,99 @@ namespace Aardvark.Base
         #region __iboundingsphere3t__ Members
 
         /// <summary>
-        /// Returns the bounding sphere of the triangle.
+        /// Returns the smallest enclosing sphere, using a longest-edge diameter for right,
+        /// obtuse or collinear triangles and zero radius for coincident points.
+        /// Non-finite points return Invalid. The radius accounts for rounding of the center.
         /// </summary>
         public readonly __sphere3t__ BoundingSphere3__tc__
         {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             get
             {
-                var edge01 = Edge01;
-                var edge02 = Edge02;
-                __ftype__ dot0101 = Vec.Dot(edge01, edge01);
-                __ftype__ dot0102 = Vec.Dot(edge01, edge02);
-                __ftype__ dot0202 = Vec.Dot(edge02, edge02);
-                __ftype__ d = 2 * (dot0101 * dot0202 - dot0102 * dot0102);
-                if (d.Abs() <= __eps__) return __sphere3t__.Invalid;
-                __ftype__ s = (dot0101 * dot0202 - dot0202 * dot0102) / d;
-                __ftype__ t = (dot0202 * dot0101 - dot0101 * dot0102) / d;
-                var p = P0;
-                var sph = new __sphere3t__();
-                if (s <= 0)
-                    sph.Center = __half__ * (P0 + P2);
-                else if (t <= 0)
-                    sph.Center = __half__ * (P0 + P1);
-                else if (s + t >= 1)
+                var a = P1 - P0; var b = P2 - P0; var c = P2 - P1;
+                var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+                var sum = aa + bb + cc;
+                if (!(sum >= __boundsLow__ && sum <= __boundsHigh__)) return BoundingSphereScaled();
+                var origin = P0; var d = a; var e = b; var f = c;
+                bool useE = bb <= cc;
+                if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+                else if (cc > aa && cc > bb) { origin = P1; d = c; e = -a; f = -b; useE = aa <= bb; }
+                var offset = __half__ * d;
+                var dot = e.Dot(f);
+                if (dot > 0)
                 {
-                    sph.Center = __half__ * (P1 + P2);
-                    p = P1;
+                    // The shorter leg stays at least 45 degrees from the longest-edge line.
+                    var relative = useE ? e : f;
+                    var perpendicular = relative - d * (relative.Dot(d) / d.LengthSquared);
+                    var pp = perpendicular.LengthSquared;
+                    if (pp == 0) return BoundingSphereScaled();
+                    offset += perpendicular * (dot / (2 * pp));
                 }
-                else
-                    sph.Center = P0 + s * edge01 + t * edge02;
-                sph.Radius = (sph.Center - p).Length;
-                return sph;
+                var center = origin + offset;
+                var r2 = Fun.Max((center - P0).LengthSquared, (center - P1).LengthSquared, (center - P2).LengthSquared);
+                return new __sphere3t__(center, r2.Sqrt());
             }
+        }
+
+        private readonly __sphere3t__ BoundingSphereScaled()
+        {
+            var p0 = (V3d)P0; var p1 = (V3d)P1; var p2 = (V3d)P2;
+            if (!p0.IsFinite || !p1.IsFinite || !p2.IsFinite) return __sphere3t__.Invalid;
+            var a = p1 - p0; var b = p2 - p0; var c = p2 - p1;
+            bool scaledPoints = !a.IsFinite || !b.IsFinite || !c.IsFinite;
+            double scale;
+            if (scaledPoints)
+            {
+                scale = Fun.Max(p0.NormMax, p1.NormMax, p2.NormMax);
+                p0 = DivideForBounds(p0, scale); p1 = DivideForBounds(p1, scale); p2 = DivideForBounds(p2, scale);
+                a = p1 - p0; b = p2 - p0; c = p2 - p1;
+            }
+            else
+            {
+                scale = Fun.Max(a.NormMax, b.NormMax, c.NormMax);
+                if (scale == 0) return new __sphere3t__(P0, 0);
+                a = DivideForBounds(a, scale); b = DivideForBounds(b, scale); c = DivideForBounds(c, scale);
+            }
+            var aa = a.LengthSquared; var bb = b.LengthSquared; var cc = c.LengthSquared;
+            var origin = p0; var d = a; var e = b; var f = c;
+            bool useE = bb <= cc;
+            if (bb > aa && bb >= cc) { d = b; e = a; f = -c; useE = aa <= cc; }
+            else if (cc > aa && cc > bb) { origin = p1; d = c; e = -a; f = -b; useE = aa <= bb; }
+            var offset = 0.5 * d;
+            double dot = e.Dot(f);
+            if (dot > 0)
+            {
+                var relative = useE ? e : f;
+                var n = d.Cross(relative);
+                double nm = n.NormMax;
+                if (nm > 0)
+                {
+                    // Normalize before the second cross product, avoiding a squared tiny normal.
+                    var perpendicular = DivideForBounds(n, nm).Cross(d);
+                    double denominator = 2 * perpendicular.Dot(relative);
+                    if (denominator != 0) offset += perpendicular * (dot / denominator);
+                }
+            }
+            var center = scaledPoints ? (origin + offset) * scale : origin + offset * scale;
+            // The minimum center lies in the convex hull; clamp only reconstruction roundoff.
+            center.X = Fun.Clamp(center.X, Fun.Min(P0.X, P1.X, P2.X), Fun.Max(P0.X, P1.X, P2.X));
+            center.Y = Fun.Clamp(center.Y, Fun.Min(P0.Y, P1.Y, P2.Y), Fun.Max(P0.Y, P1.Y, P2.Y));
+            center.Z = Fun.Clamp(center.Z, Fun.Min(P0.Z, P1.Z, P2.Z), Fun.Max(P0.Z, P1.Z, P2.Z));
+            var rounded = (__v3t__)center;
+            double radius = Fun.Max(BoundsDistance((V3d)rounded, (V3d)P0), BoundsDistance((V3d)rounded, (V3d)P1), BoundsDistance((V3d)rounded, (V3d)P2));
+            return new __sphere3t__(rounded, (__ftype__)radius);
+        }
+
+        private static V3d DivideForBounds(V3d p, double scale)
+            => new V3d(p.X / scale, p.Y / scale, p.Z / scale);
+
+        private static double BoundsDistance(V3d a, V3d b)
+        {
+            var d = a - b;
+            double scale = d.NormMax;
+            if (scale == 0 || double.IsPositiveInfinity(scale)) return scale;
+            d = DivideForBounds(d, scale);
+            return scale * d.Length;
         }
 
         #endregion

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.cs
@@ -1,0 +1,176 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using System;
+
+namespace Aardvark.Base.Benchmarks.Geometry
+{
+    // dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- --filter '*TriangleBoundingVolumeBenchmark*'
+    [MemoryDiagnoser]
+    [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+    [CategoriesColumn]
+    public class TriangleBoundingVolumeBenchmark
+    {
+        private const int Count = 256;
+        private Triangle2f[] _t2f;
+        private Triangle2d[] _t2d;
+        private Triangle3f[] _t3f;
+        private Triangle3d[] _t3d;
+
+        [Params("Acute", "Right", "Obtuse", "Mixed", "Exceptional")]
+        public string Case { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            _t2f = new Triangle2f[Count]; _t2d = new Triangle2d[Count];
+            _t3f = new Triangle3f[Count]; _t3d = new Triangle3d[Count];
+            var random = new Random(6151);
+            for (int i = 0; i < Count; i++)
+            {
+                int shape = Case == "Acute" ? 0 : Case == "Right" ? 1 : Case == "Obtuse" ? 2 : i % 3;
+                var c = shape == 0 ? new V2d(1, 2) : shape == 1 ? new V2d(0, 2) : new V2d(1, 0.25);
+                var origin = new V2d(random.Next(-32, 33) * 0.25, random.Next(-32, 33) * 0.25);
+                double scale = Math.Pow(2, i % 3 - 1);
+                V2d Map(V2d p) => origin + scale * ((i & 1) == 0 ? p : new V2d(-p.Y, p.X));
+                var a = Map(V2d.Zero); var b = Map(new V2d(2, 0)); c = Map(c);
+                var af = (V2f)a; var bf = (V2f)b; var cf = (V2f)c;
+                if (Case == "Exceptional")
+                {
+                    double sd = Math.Pow(2, (i & 1) == 0 ? 600 : -600);
+                    float sf = (float)Math.Pow(2, (i & 1) == 0 ? 80 : -80);
+                    a *= sd; b *= sd; c *= sd;
+                    af *= sf; bf *= sf; cf *= sf;
+                }
+                _t2d[i] = new Triangle2d(a, b, c);
+                _t2f[i] = new Triangle2f(af, bf, cf);
+                V3d Embed(V2d p) => p.X * new V3d(0.6, 0.8, 0) + p.Y * new V3d(-0.48, 0.36, 0.8);
+                V3f Embedf(V2f p) => p.X * new V3f(0.6f, 0.8f, 0) + p.Y * new V3f(-0.48f, 0.36f, 0.8f);
+                _t3d[i] = new Triangle3d(Embed(a), Embed(b), Embed(c));
+                _t3f[i] = new Triangle3f(Embedf(af), Embedf(bf), Embedf(cf));
+            }
+        }
+
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("2D float")]
+        public float Previous2f()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++) { var b = Previous(in _t2f[i]); sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("2D float")]
+        public float Revised2f()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++) { var b = _t2f[i].BoundingCircle2f; sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("2D double")]
+        public double Previous2d()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++) { var b = Previous(in _t2d[i]); sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("2D double")]
+        public double Revised2d()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++) { var b = _t2d[i].BoundingCircle2d; sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("3D float")]
+        public float Previous3f()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++) { var b = Previous(in _t3f[i]); sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("3D float")]
+        public float Revised3f()
+        {
+            float sum = 0;
+            for (int i = 0; i < Count; i++) { var b = _t3f[i].BoundingSphere3f; sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(Baseline = true, OperationsPerInvoke = Count), BenchmarkCategory("3D double")]
+        public double Previous3d()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++) { var b = Previous(in _t3d[i]); sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+        [Benchmark(OperationsPerInvoke = Count), BenchmarkCategory("3D double")]
+        public double Revised3d()
+        {
+            double sum = 0;
+            for (int i = 0; i < Count; i++) { var b = _t3d[i].BoundingSphere3d; sum += b.Center.X + b.Radius; }
+            return sum;
+        }
+
+        // Original property bodies at 3db25671; readonly-reference receivers preserve their calling convention.
+        private static Circle2f Previous(in Triangle2f tri)
+        {
+            var a = tri.P1 - tri.P0; var b = tri.P2 - tri.P0;
+            float aa = a.Dot(a), ab = a.Dot(b), bb = b.Dot(b);
+            float d = 2 * (aa * bb - ab * ab);
+            if (d.Abs() <= 1e-4f) return Circle2f.Invalid;
+            float s = (aa * bb - bb * ab) / d;
+            float t = (bb * aa - aa * ab) / d;
+            var p = tri.P0; var bound = new Circle2f();
+            if (s <= 0) bound.Center = 0.5f * (tri.P0 + tri.P2);
+            else if (t <= 0) bound.Center = 0.5f * (tri.P0 + tri.P1);
+            else if (s + t >= 1) { bound.Center = 0.5f * (tri.P1 + tri.P2); p = tri.P1; }
+            else bound.Center = tri.P0 + s * a + t * b;
+            bound.Radius = (bound.Center - p).Length;
+            return bound;
+        }
+        private static Circle2d Previous(in Triangle2d tri)
+        {
+            var a = tri.P1 - tri.P0; var b = tri.P2 - tri.P0;
+            double aa = a.Dot(a), ab = a.Dot(b), bb = b.Dot(b);
+            double d = 2 * (aa * bb - ab * ab);
+            if (d.Abs() <= 1e-6) return Circle2d.Invalid;
+            double s = (aa * bb - bb * ab) / d;
+            double t = (bb * aa - aa * ab) / d;
+            var p = tri.P0; var bound = new Circle2d();
+            if (s <= 0) bound.Center = 0.5 * (tri.P0 + tri.P2);
+            else if (t <= 0) bound.Center = 0.5 * (tri.P0 + tri.P1);
+            else if (s + t >= 1) { bound.Center = 0.5 * (tri.P1 + tri.P2); p = tri.P1; }
+            else bound.Center = tri.P0 + s * a + t * b;
+            bound.Radius = (bound.Center - p).Length;
+            return bound;
+        }
+        private static Sphere3f Previous(in Triangle3f tri)
+        {
+            var a = tri.Edge01; var b = tri.Edge02;
+            float aa = a.Dot(a), ab = a.Dot(b), bb = b.Dot(b);
+            float d = 2 * (aa * bb - ab * ab);
+            if (d.Abs() <= 1e-5f) return Sphere3f.Invalid;
+            float s = (aa * bb - bb * ab) / d;
+            float t = (bb * aa - aa * ab) / d;
+            var p = tri.P0; var bound = new Sphere3f();
+            if (s <= 0) bound.Center = 0.5f * (tri.P0 + tri.P2);
+            else if (t <= 0) bound.Center = 0.5f * (tri.P0 + tri.P1);
+            else if (s + t >= 1) { bound.Center = 0.5f * (tri.P1 + tri.P2); p = tri.P1; }
+            else bound.Center = tri.P0 + s * a + t * b;
+            bound.Radius = (bound.Center - p).Length;
+            return bound;
+        }
+        private static Sphere3d Previous(in Triangle3d tri)
+        {
+            var a = tri.Edge01; var b = tri.Edge02;
+            double aa = a.Dot(a), ab = a.Dot(b), bb = b.Dot(b);
+            double d = 2 * (aa * bb - ab * ab);
+            if (d.Abs() <= 1e-9) return Sphere3d.Invalid;
+            double s = (aa * bb - bb * ab) / d;
+            double t = (bb * aa - aa * ab) / d;
+            var p = tri.P0; var bound = new Sphere3d();
+            if (s <= 0) bound.Center = 0.5 * (tri.P0 + tri.P2);
+            else if (t <= 0) bound.Center = 0.5 * (tri.P0 + tri.P1);
+            else if (s + t >= 1) { bound.Center = 0.5 * (tri.P1 + tri.P2); p = tri.P1; }
+            else bound.Center = tri.P0 + s * a + t * b;
+            bound.Radius = (bound.Center - p).Length;
+            return bound;
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.md
@@ -2,8 +2,10 @@
 
 Tracking: [#137](https://github.com/aardvark-platform/aardvark.base/issues/137).
 
-**Performance acceptance is blocked.** Faster 2D float queries do not offset
-regressions in other independently used variants.
+**Performance acceptance passed.** No ordinary revised workload shows a
+statistically distinguishable regression, and most show clear gains.
+Exceptional-scale costs are reported separately because the baseline does not
+produce equivalent valid bounds.
 
 ```sh
 dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
@@ -28,25 +30,29 @@ per second, not an average of reciprocal samples.
 
 | Variant | Case | Before ns | After ns | Before Mbound/s | After Mbound/s |
 | --- | --- | ---: | ---: | ---: | ---: |
-| 2D double | Acute | 7.201 | 8.607 | 138.870 | 116.185 |
-| 2D double | Right | 5.716 | 7.459 | 174.948 | 134.066 |
-| 2D double | Obtuse | 5.207 | 6.593 | 192.049 | 151.676 |
-| 2D double | Mixed | 6.093 | 7.776 | 164.123 | 128.601 |
-| 2D float | Acute | 11.300 | 8.001 | 88.496 | 124.984 |
-| 2D float | Right | 11.584 | 6.838 | 86.326 | 146.242 |
-| 2D float | Obtuse | 11.017 | 5.891 | 90.769 | 169.750 |
-| 2D float | Mixed | 11.638 | 6.882 | 85.925 | 145.307 |
-| 3D double | Acute | 8.991 | 18.417 | 111.222 | 54.298 |
-| 3D double | Right | 8.142 | 17.468 | 122.820 | 57.248 |
-| 3D double | Obtuse | 6.294 | 9.672 | 158.881 | 103.391 |
-| 3D double | Mixed | 7.701 | 16.359 | 129.853 | 61.128 |
-| 3D float | Acute | 12.172 | 17.721 | 82.156 | 56.430 |
-| 3D float | Right | 13.131 | 17.187 | 76.156 | 58.184 |
-| 3D float | Obtuse | 12.360 | 8.928 | 80.906 | 112.007 |
-| 3D float | Mixed | 12.513 | 14.947 | 79.917 | 66.903 |
+| 2D double | Acute | 6.924 | 6.472 | 144.425 | 154.512 |
+| 2D double | Right | 5.394 | 3.937 | 185.391 | 254.001 |
+| 2D double | Obtuse | 5.095 | 4.452 | 196.271 | 224.618 |
+| 2D double | Mixed | 5.939 | 5.142 | 168.379 | 194.477 |
+| 2D float | Acute | 11.169 | 6.293 | 89.534 | 158.907 |
+| 2D float | Right | 10.947 | 3.520 | 91.349 | 284.091 |
+| 2D float | Obtuse | 10.649 | 3.829 | 93.906 | 261.165 |
+| 2D float | Mixed | 11.150 | 4.527 | 89.686 | 220.897 |
+| 3D double | Acute | 8.991 | 8.487 | 111.222 | 117.827 |
+| 3D double | Right | 7.949 | 7.201 | 125.802 | 138.870 |
+| 3D double | Obtuse | 6.319 | 5.881 | 158.253 | 170.039 |
+| 3D double | Mixed | 7.435 | 7.471 | 134.499 | 133.851 |
+| 3D float | Acute | 11.570 | 8.302 | 86.430 | 120.453 |
+| 3D float | Right | 12.453 | 6.917 | 80.302 | 144.571 |
+| 3D float | Obtuse | 11.684 | 5.719 | 85.587 | 174.856 |
+| 3D float | Mixed | 11.936 | 7.092 | 83.780 | 141.004 |
 
-For acute 3D double queries, the 99.9% confidence half-widths are 0.1948 ns before
-and 0.2034 ns after. The regression is not dismissed as measurement noise.
+The full forty-method run supplied the 2D values. The 3D values are from focused
+warning-free reruns with identical settings after making determinant evaluation
+lazy on diameter paths. The extended 32-iteration 3D-double run measured mixed at
+`7.435 ± 0.147` versus `7.471 ± 0.192 ns` (99.9% confidence, ratio `1.01 ± 0.06`),
+which is statistically unchanged; acute, right, and obtuse improved. Every run
+compares each implementation in the same generated executable.
 
 ## Exceptional scales
 
@@ -57,15 +63,14 @@ throughput comparisons and are kept separate from ordinary-path acceptance.
 
 | Variant | Before ns | After ns | Before Mbound/s | After Mbound/s |
 | --- | ---: | ---: | ---: | ---: |
-| 2D double | 5.013 | 30.436 | 199.481 | 32.856 |
-| 2D float | 46.532 | 94.407 | 21.491 | 10.592 |
-| 3D double | 6.152 | 51.770 | 162.549 | 19.316 |
-| 3D float | 25.367 | 90.714 | 39.421 | 11.024 |
+| 2D double | 4.784 | 34.211 | 209.030 | 29.230 |
+| 2D float | 42.046 | 87.608 | 23.783 | 11.414 |
+| 3D double | 5.864 | 54.262 | 170.532 | 18.429 |
+| 3D float | 23.655 | 85.008 | 42.274 | 11.764 |
 
 ## Allocations and run quality
 
 MemoryDiagnoser measured **0 B per bound for every baseline and revised case**,
-including exceptional scales. The isolated run completed all forty measurements
-without BenchmarkDotNet warnings. A preliminary in-process run also showed
-regressions; it is not used to override the isolated results. No inputs or
-correctness checks were weakened to claim acceptance.
+including exceptional scales. One baseline 3D-float distribution was multimodal
+in the full run, so all 3D-float values above come from a clean focused rerun.
+No inputs or correctness checks were weakened to claim acceptance.

--- a/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/Geometry/TriangleBoundingVolumeBenchmark.md
@@ -1,0 +1,71 @@
+# Triangle bounding-volume benchmarks
+
+Tracking: [#137](https://github.com/aardvark-platform/aardvark.base/issues/137).
+
+**Performance acceptance is blocked.** Faster 2D float queries do not offset
+regressions in other independently used variants.
+
+```sh
+dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- \
+  --filter '*TriangleBoundingVolumeBenchmark*' \
+  --warmupCount 8 --iterationCount 16 --iterationTime 1000 --buildTimeout 600
+```
+
+Baseline methods reproduce the property bodies at `3db25671`, with readonly
+reference receivers. Each invocation processes 256 prebuilt triangles; generation,
+translation, orientation and scaling are outside timing. Both implementations
+receive identical arrays. The 3D datasets use an oblique orthonormal embedding.
+The mixed dataset alternates acute, right and obtuse input shapes. Floating-point
+rounding of the embedding can move nominally right cases slightly to either side
+of the right-angle boundary.
+
+## Ordinary inputs
+
+Release, .NET 8.0.26, isolated BenchmarkDotNet processes on the same processor
+affinity, eight warmups and sixteen one-second target iterations. Times are
+arithmetic means per bound. Throughput is `1000 / mean_ns` in millions of bounds
+per second, not an average of reciprocal samples.
+
+| Variant | Case | Before ns | After ns | Before Mbound/s | After Mbound/s |
+| --- | --- | ---: | ---: | ---: | ---: |
+| 2D double | Acute | 7.201 | 8.607 | 138.870 | 116.185 |
+| 2D double | Right | 5.716 | 7.459 | 174.948 | 134.066 |
+| 2D double | Obtuse | 5.207 | 6.593 | 192.049 | 151.676 |
+| 2D double | Mixed | 6.093 | 7.776 | 164.123 | 128.601 |
+| 2D float | Acute | 11.300 | 8.001 | 88.496 | 124.984 |
+| 2D float | Right | 11.584 | 6.838 | 86.326 | 146.242 |
+| 2D float | Obtuse | 11.017 | 5.891 | 90.769 | 169.750 |
+| 2D float | Mixed | 11.638 | 6.882 | 85.925 | 145.307 |
+| 3D double | Acute | 8.991 | 18.417 | 111.222 | 54.298 |
+| 3D double | Right | 8.142 | 17.468 | 122.820 | 57.248 |
+| 3D double | Obtuse | 6.294 | 9.672 | 158.881 | 103.391 |
+| 3D double | Mixed | 7.701 | 16.359 | 129.853 | 61.128 |
+| 3D float | Acute | 12.172 | 17.721 | 82.156 | 56.430 |
+| 3D float | Right | 13.131 | 17.187 | 76.156 | 58.184 |
+| 3D float | Obtuse | 12.360 | 8.928 | 80.906 | 112.007 |
+| 3D float | Mixed | 12.513 | 14.947 | 79.917 | 66.903 |
+
+For acute 3D double queries, the 99.9% confidence half-widths are 0.1948 ns before
+and 0.2034 ns after. The regression is not dismissed as measurement noise.
+
+## Exceptional scales
+
+These datasets multiply the ordinary coordinates by alternating large/small
+powers of two: ±600 exponents for double, ±80 for float. The previous algorithm
+can return Invalid or non-finite bounds; these are not equivalent correct-result
+throughput comparisons and are kept separate from ordinary-path acceptance.
+
+| Variant | Before ns | After ns | Before Mbound/s | After Mbound/s |
+| --- | ---: | ---: | ---: | ---: |
+| 2D double | 5.013 | 30.436 | 199.481 | 32.856 |
+| 2D float | 46.532 | 94.407 | 21.491 | 10.592 |
+| 3D double | 6.152 | 51.770 | 162.549 | 19.316 |
+| 3D float | 25.367 | 90.714 | 39.421 | 11.024 |
+
+## Allocations and run quality
+
+MemoryDiagnoser measured **0 B per bound for every baseline and revised case**,
+including exceptional scales. The isolated run completed all forty measurements
+without BenchmarkDotNet warnings. A preliminary in-process run also showed
+regressions; it is not used to override the isolated results. No inputs or
+correctness checks were weakened to claim acceptance.

--- a/src/Tests/Aardvark.Base.Tests/Geometry/TriangleBoundingVolumeTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/Geometry/TriangleBoundingVolumeTests.cs
@@ -1,7 +1,6 @@
 using Aardvark.Base;
 using NUnit.Framework;
 using System;
-using System.Collections.Generic;
 
 namespace Aardvark.Tests.Geometry
 {
@@ -92,6 +91,31 @@ namespace Aardvark.Tests.Geometry
         }
 
         [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void RoundedTranslatedCentersEncloseEveryPermutation(bool three, bool single)
+        {
+            double origin = Math.Pow(2, single ? 23 : 52);
+            var shapes = new[]
+            {
+                new[] { V3d.Zero, V3d.Zero, V3d.XAxis },
+                new[] { V3d.Zero, V3d.YAxis, new V3d(3, 1, 0) },
+                new[] { V3d.Zero, new V3d(4, 0, 0), new V3d(2, 3, 0) }
+            };
+            var shift = new V3d(origin, origin, three ? origin : 0);
+            foreach (var shape in shapes)
+                foreach (var order in Permutations)
+                {
+                    var a = shift + shape[order[0]];
+                    var b = shift + shape[order[1]];
+                    var c = shift + shape[order[2]];
+                    var bound = Get(a, b, c, three, single);
+                    Assert.That(bound.Valid && bound.Center.IsFinite && double.IsFinite(bound.Radius), Is.True);
+                    ContainsAtTargetPrecision(bound, a, three, single);
+                    ContainsAtTargetPrecision(bound, b, three, single);
+                    ContainsAtTargetPrecision(bound, c, three, single);
+                }
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
         public void NonFiniteInputsReturnInvalid(bool three, bool single)
         {
             foreach (double bad in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
@@ -161,6 +185,9 @@ namespace Aardvark.Tests.Geometry
             Contains(result, a, scale, tolerance);
             Contains(result, b, scale, tolerance);
             Contains(result, c, scale, tolerance);
+            ContainsAtTargetPrecision(result, a, three, single);
+            ContainsAtTargetPrecision(result, b, three, single);
+            ContainsAtTargetPrecision(result, c, three, single);
         }
 
         private static void Contains((V3d Center, double Radius, bool Valid) bound, V3d point, double scale, double tolerance)
@@ -168,6 +195,22 @@ namespace Aardvark.Tests.Geometry
             var delta = point / scale - bound.Center / scale;
             Assert.That(Math.Sqrt(delta.X * delta.X + delta.Y * delta.Y + delta.Z * delta.Z),
                 Is.LessThanOrEqualTo(bound.Radius / scale + tolerance));
+        }
+
+        private static void ContainsAtTargetPrecision((V3d Center, double Radius, bool Valid) bound, V3d point, bool three, bool single)
+        {
+            double distance;
+            if (single)
+            {
+                var delta = (V3f)point - (V3f)bound.Center;
+                distance = three ? delta.Length : delta.XY.Length;
+            }
+            else
+            {
+                var delta = point - bound.Center;
+                distance = three ? delta.Length : delta.XY.Length;
+            }
+            if (double.IsFinite(distance)) Assert.That(distance, Is.LessThanOrEqualTo(bound.Radius));
         }
 
         // Bounded integer inputs only: enumerate diameter candidates, then solve the absolute

--- a/src/Tests/Aardvark.Base.Tests/Geometry/TriangleBoundingVolumeTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/Geometry/TriangleBoundingVolumeTests.cs
@@ -1,0 +1,230 @@
+using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+
+namespace Aardvark.Tests.Geometry
+{
+    [TestFixture]
+    public class TriangleBoundingVolumeTests
+    {
+        private static readonly int[][] Permutations =
+        {
+            new[] { 0, 1, 2 }, new[] { 0, 2, 1 }, new[] { 1, 0, 2 },
+            new[] { 1, 2, 0 }, new[] { 2, 0, 1 }, new[] { 2, 1, 0 }
+        };
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void AnalyticBoundsAcrossScalesAndPermutations(bool three, bool single)
+        {
+            var shapes = new (V3d A, V3d B, V3d C, V3d Center, double Radius)[]
+            {
+                (V3d.Zero, V3d.XAxis, V3d.YAxis, new V3d(0.5, 0.5, 0), Math.Sqrt(0.5)),
+                (V3d.Zero, new V3d(0.01, 0, 0), new V3d(0, 0.01, 0), new V3d(0.005, 0.005, 0), 0.01 * Math.Sqrt(0.5)),
+                (V3d.Zero, new V3d(0.001, 0, 0), new V3d(0, 0.001, 0), new V3d(0.0005, 0.0005, 0), 0.001 * Math.Sqrt(0.5)),
+                (V3d.Zero, V3d.XAxis, new V3d(0.5, 1e-8, 0), new V3d(0.5, 0, 0), 0.5),
+                (V3d.Zero, new V3d(2, 0, 0), new V3d(1, 2, 0), new V3d(1, 0.75, 0), 1.25),
+                (V3d.Zero, new V3d(2, 0, 0), new V3d(0.5, 0.25, 0), V3d.XAxis, 1),
+                (new V3d(-2, -2, 0), new V3d(1, 1, 0), new V3d(4, 4, 0), new V3d(1, 1, 0), 3 * Math.Sqrt(2)),
+                (V3d.Zero, V3d.Zero, V3d.XAxis, new V3d(0.5, 0, 0), 0.5),
+                (V3d.One, V3d.One, V3d.One, V3d.One, 0)
+            };
+            int[] powers = single ? new[] { -130, -50, -10, 0, 10, 50, 120 } : new[] { -1040, -500, -40, 0, 40, 500, 1000 };
+            foreach (var shape in shapes)
+                foreach (int power in powers)
+                    foreach (bool translated in new[] { false, true })
+                        foreach (bool rotated in three ? new[] { false, true } : new[] { false })
+                        {
+                            double scale = Math.Pow(2, power);
+                            var shift = translated ? new V3d(4, -8, three ? 16 : 0) : V3d.Zero;
+                            V3d Map(V3d p)
+                            {
+                                if (!three) p.Z = 0;
+                                if (rotated) p = p.X * new V3d(0.6, 0.8, 0) + p.Y * new V3d(-0.48, 0.36, 0.8) + p.Z * new V3d(0.64, -0.48, 0.6);
+                                return (p + shift) * scale;
+                            }
+                            var points = new[] { Map(shape.A), Map(shape.B), Map(shape.C) };
+                            foreach (var order in Permutations)
+                                Check(points[order[0]], points[order[1]], points[order[2]], Map(shape.Center), shape.Radius * scale,
+                                    scale, three, single);
+                        }
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void ThinAcuteTrianglesUseStableLocalCenters(bool three, bool single)
+        {
+            double h = single ? 1e-4 : 1e-8;
+            double delta = 0.5 * h * h;
+            double y = (delta * delta + 0.5 * h * h) / (2 * h);
+            var p = new[] { V3d.Zero, V3d.XAxis, new V3d(delta, h, 0) };
+            foreach (var order in Permutations)
+                Check(p[order[0]], p[order[1]], p[order[2]], new V3d(0.5, y, 0), Math.Sqrt(0.25 + y * y), 1, three, single);
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void OverflowingDifferencesStillHaveRepresentableBounds(bool three, bool single)
+        {
+            double max = single ? float.MaxValue : double.MaxValue;
+            var points = new[] { new V3d(-max, 0, 0), new V3d(max, 0, 0), new V3d(0, 0.5 * max, 0) };
+            foreach (var order in Permutations)
+                Check(points[order[0]], points[order[1]], points[order[2]], V3d.Zero, max, max, three, single);
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void LargeTranslationsRetainLocalExtents(bool three, bool single)
+        {
+            double origin = Math.Pow(2, single ? 100 : 900);
+            double step = Math.Pow(2, single ? 77 : 848);
+            var a = new V3d(origin, origin, three ? origin : 0);
+            var b = a + new V3d(2 * step, 0, 0);
+            var c = a + new V3d(step, 0, 0);
+            foreach (var order in Permutations)
+            {
+                var p = new[] { a, b, c };
+                Check(p[order[0]], p[order[1]], p[order[2]], c, step, step, three, single);
+            }
+
+            // When the ideal midpoint is not representable, the rounded center must still enclose both ends.
+            var bound = Get(a, a + new V3d(step, 0, 0), a, three, single);
+            Assert.That(bound.Valid && bound.Center.IsFinite && double.IsFinite(bound.Radius), Is.True);
+            Contains(bound, a, step, 0);
+            Contains(bound, a + new V3d(step, 0, 0), step, 0);
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void NonFiniteInputsReturnInvalid(bool three, bool single)
+        {
+            foreach (double bad in new[] { double.NaN, double.PositiveInfinity, double.NegativeInfinity })
+                for (int vertex = 0; vertex < 3; vertex++)
+                    for (int axis = 0; axis < (three ? 3 : 2); axis++)
+                    {
+                        var p = new[] { V3d.Zero, V3d.XAxis, V3d.YAxis };
+                        p[vertex][axis] = bad;
+                        var bound = Get(p[0], p[1], p[2], three, single);
+                        Assert.That(bound.Valid, Is.False);
+                        Assert.That(bound.Radius, Is.EqualTo(-1));
+                    }
+        }
+
+        [TestCase(false, false), TestCase(false, true), TestCase(true, false), TestCase(true, true)]
+        public void SeededBoundsMatchIndependentReference(bool three, bool single)
+        {
+            var random = new Random(7013);
+            V3d Next() => new V3d(random.Next(-8, 9), random.Next(-8, 9), three ? random.Next(-8, 9) : 0);
+            for (int i = 0; i < 5000; i++)
+            {
+                var a = Next(); var b = Next(); var c = Next();
+                var reference = Reference(a, b, c, three);
+                Check(a, b, c, reference.Center, reference.Radius, 16, three, single);
+            }
+        }
+
+        private static (V3d Center, double Radius, bool Valid) Get(V3d a, V3d b, V3d c, bool three, bool single)
+        {
+            if (three)
+            {
+                if (single)
+                {
+                    var bound = new Triangle3f((V3f)a, (V3f)b, (V3f)c).BoundingSphere3f;
+                    return ((V3d)bound.Center, bound.Radius, bound.IsValid);
+                }
+                else
+                {
+                    var bound = new Triangle3d(a, b, c).BoundingSphere3d;
+                    return (bound.Center, bound.Radius, bound.IsValid);
+                }
+            }
+            else
+            {
+                if (single)
+                {
+                    var bound = new Triangle2f(new V2f((float)a.X, (float)a.Y), new V2f((float)b.X, (float)b.Y), new V2f((float)c.X, (float)c.Y)).BoundingCircle2f;
+                    return (new V3d(bound.Center.X, bound.Center.Y, 0), bound.Radius, bound.IsValid);
+                }
+                else
+                {
+                    var bound = new Triangle2d(a.XY, b.XY, c.XY).BoundingCircle2d;
+                    return (new V3d(bound.Center.X, bound.Center.Y, 0), bound.Radius, bound.IsValid);
+                }
+            }
+        }
+
+        private static void Check(V3d a, V3d b, V3d c, V3d center, double radius, double scale, bool three, bool single)
+        {
+            var result = Get(a, b, c, three, single);
+            string context = $"a={a}, b={b}, c={c}, single={single}, three={three}";
+            double tolerance = single ? 4e-5 + 8 * ((double)float.Epsilon / scale) : 4e-13 + 8 * (double.Epsilon / scale);
+            Assert.That(result.Valid && result.Center.IsFinite && double.IsFinite(result.Radius), Is.True, context);
+            Assert.That((result.Center / scale - center / scale).NormMax, Is.LessThanOrEqualTo(tolerance), context);
+            Assert.That(Math.Abs(result.Radius / scale - radius / scale), Is.LessThanOrEqualTo(tolerance), context);
+            if (single) { a = (V3d)(V3f)a; b = (V3d)(V3f)b; c = (V3d)(V3f)c; }
+            Contains(result, a, scale, tolerance);
+            Contains(result, b, scale, tolerance);
+            Contains(result, c, scale, tolerance);
+        }
+
+        private static void Contains((V3d Center, double Radius, bool Valid) bound, V3d point, double scale, double tolerance)
+        {
+            var delta = point / scale - bound.Center / scale;
+            Assert.That(Math.Sqrt(delta.X * delta.X + delta.Y * delta.Y + delta.Z * delta.Z),
+                Is.LessThanOrEqualTo(bound.Radius / scale + tolerance));
+        }
+
+        // Bounded integer inputs only: enumerate diameter candidates, then solve the absolute
+        // equidistance/plane equations by independent Gaussian elimination for a circum-bound.
+        private static (V3d Center, double Radius) Reference(V3d a, V3d b, V3d c, bool three)
+        {
+            var points = new[] { a, b, c };
+            V3d best = V3d.NaN;
+            double bestSquared = double.PositiveInfinity;
+            void Candidate(V3d center)
+            {
+                double r2 = (center - a).LengthSquared;
+                double rb = (center - b).LengthSquared;
+                double rc = (center - c).LengthSquared;
+                // A candidate radius may be determined by any two endpoints.
+                double radius = Math.Max(r2, Math.Max(rb, rc));
+                if (radius < bestSquared) { best = center; bestSquared = radius; }
+            }
+            for (int i = 0; i < 3; i++)
+                for (int j = i + 1; j < 3; j++)
+                {
+                    var center = (points[i] + points[j]) * 0.5;
+                    double r2 = (points[i] - center).LengthSquared;
+                    bool contains = true;
+                    foreach (var p in points) contains &= (p - center).LengthSquared <= r2 + 1e-12;
+                    if (contains) Candidate(center);
+                }
+            int n = three ? 3 : 2;
+            var matrix = new double[n, n + 1];
+            var u = b - a; var v = c - a;
+            for (int j = 0; j < n; j++) { matrix[0, j] = 2 * u[j]; matrix[1, j] = 2 * v[j]; }
+            matrix[0, n] = b.LengthSquared - a.LengthSquared;
+            matrix[1, n] = c.LengthSquared - a.LengthSquared;
+            if (three)
+            {
+                var normal = new V3d(u.Y * v.Z - u.Z * v.Y, u.Z * v.X - u.X * v.Z, u.X * v.Y - u.Y * v.X);
+                for (int j = 0; j < 3; j++) matrix[2, j] = normal[j];
+                matrix[2, 3] = normal.X * a.X + normal.Y * a.Y + normal.Z * a.Z;
+            }
+            bool nonsingular = true;
+            for (int k = 0; k < n; k++)
+            {
+                int pivot = k;
+                for (int i = k + 1; i < n; i++) if (Math.Abs(matrix[i, k]) > Math.Abs(matrix[pivot, k])) pivot = i;
+                if (matrix[pivot, k] == 0) { nonsingular = false; break; }
+                for (int j = k; j <= n; j++) (matrix[k, j], matrix[pivot, j]) = (matrix[pivot, j], matrix[k, j]);
+                double divisor = matrix[k, k];
+                for (int j = k; j <= n; j++) matrix[k, j] /= divisor;
+                for (int i = 0; i < n; i++)
+                    if (i != k)
+                    {
+                        double factor = matrix[i, k];
+                        for (int j = k; j <= n; j++) matrix[i, j] -= factor * matrix[k, j];
+                    }
+            }
+            if (nonsingular) Candidate(new V3d(matrix[0, n], matrix[1, n], three ? matrix[2, n] : 0));
+            return (best, Math.Sqrt(bestSquared));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #137.

Replace the absolute determinant cutoff with minimum enclosing circle/sphere calculations for all four Triangle2/3 float/double variants:

- Longest-edge diameters for right, obtuse and collinear triangles; zero radius for coincident points.
- Stable acute centers, scaled exceptional arithmetic, rounded-center containment and Invalid for non-finite vertices.
- Unchanged CircumCircle APIs; regenerated templates and aligned XML/reference semantics.
- Analytic permutation/scale/translation/rotation regressions and 20,000 independent-reference comparisons.

The optimized scalar fast path clears the performance gate. Ordinary 2D and 3D-float cases improve, while an extended 32-iteration 3D-double run improves acute/right/obtuse and finds mixed statistically unchanged (7.435 ± 0.147 vs 7.471 ± 0.192 ns at 99.9% confidence; ratio 1.01 ± 0.06). Every workload remains at 0 B. Exceptional-scale costs are reported separately because the baseline returns invalid or non-finite bounds.

Validation: 2,624 maintained tests pass with 31 existing skips; focused Debug/Release tests, both core target frameworks, generated-source validation, build, and docs checks are clean. Full measurements are retained in the benchmark report.