### PR TITLE
Respect live sorted-set view bounds in neighbour queries

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,4 @@
+- [Base] Corrected and accelerated comparer-ordered neighbour queries on live sorted-set views
 - [Base] Corrected and accelerated scale-safe minimum triangle bounding circles and spheres
 - [Base] Fixed `Cell.Intersects` and `Cell2d.Intersects`
 - [Base] Corrected winding- and translation-stable 2D and 3D polygon centroids

--- a/ai/COLLECTIONS.md
+++ b/ai/COLLECTIONS.md
@@ -95,11 +95,29 @@ set.Clear();
 set.UnionWith(other);
 ```
 
+## SortedSetExt<T> Neighbours
+
+Neighbour order follows the configured comparer, including descending comparers.
+`FindNeighbours` and `FindNeighboursV` return the strict predecessor, the actual
+stored comparer-equal value, and the strict successor. `TryFindSmaller` and
+`TryFindGreater` use the same lookup. Absent value outputs are `default(T)`;
+optional outputs are `None`.
+
+`GetViewBetween` has inclusive bounds. Neighbour queries see current parent-set
+contents, even after parent mutations, and queries outside the view return its
+nearest boundary-side element rather than an element outside the view. Lookup
+is logarithmic in parent-tree size and does not recount or enumerate the view.
+The value/try APIs allocate no managed memory. F# `SortedSet.neighbourhood`
+exposes the same results as options.
+
 ## SingleEntryDict
 
 `SingleEntryDict<TKey, TValue>` exists in `Symbol/Dicts.cs` and is optimized for one optional key/value entry. It supports normal `IDict<TKey, TValue>` lookup, removal, and re-adding the configured key after removal.
 
 ## Source Anchors
+
+- `src/Aardvark.Base/AlgoDat/ExtendedCore/SortedSetExt.cs`
+- `src/Aardvark.Base.FSharp/Utilities/Interop/SortedSet.fs`
 
 - `src/Aardvark.Base/Symbol/Symbol.cs`
 - `src/Aardvark.Base/Symbol/Dict_auto.cs`

--- a/src/Aardvark.Base/AlgoDat/ExtendedCore/SortedSetExt.cs
+++ b/src/Aardvark.Base/AlgoDat/ExtendedCore/SortedSetExt.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -1944,8 +1945,8 @@ namespace Aardvark.Base
 
 
         /// <summary>
-        /// Returns a subset of this tree ranging from values lBound to uBound
-        /// Any changes made to the subset reflect in the actual tree
+        /// Returns a live view between the inclusive bounds in comparer order.
+        /// Changes to either the view or its underlying set are reflected in the other.
         /// </summary>
         /// <param name="lowerValue">Lowest Value allowed in the subset</param>
         /// <param name="upperValue">Highest Value allowed in the subset</param>        
@@ -1958,6 +1959,10 @@ namespace Aardvark.Base
             return new TreeSubSet(this, lowerValue, upperValue, true, true);
         }
 
+        /// <summary>
+        /// Finds the strict successor in comparer order, restricted to the current view bounds.
+        /// Reflects parent-set mutations; returns false and default(T) when absent.
+        /// </summary>
         public bool TryFindGreater(T lowerValue, out T result)
         {
             var tup = FindNeighbours(lowerValue);
@@ -1973,6 +1978,10 @@ namespace Aardvark.Base
             }
         }
 
+        /// <summary>
+        /// Finds the strict predecessor in comparer order, restricted to the current view bounds.
+        /// Reflects parent-set mutations; returns false and default(T) when absent.
+        /// </summary>
         public bool TryFindSmaller(T upperValue, out T result)
         {
             var tup = FindNeighbours(upperValue);
@@ -1988,6 +1997,10 @@ namespace Aardvark.Base
             }
         }
 
+        /// <summary>
+        /// Finds the strict predecessor, stored comparer-equal value and strict successor in comparer order.
+        /// View bounds are inclusive and reflect parent-set mutations; absent results are None.
+        /// </summary>
         public void FindNeighbours(T value, out Optional<T> lower, out Optional<T> self, out Optional<T> upper)
         {
             var tup = FindNeighbours(value);
@@ -2003,8 +2016,9 @@ namespace Aardvark.Base
         }
 
         /// <summary>
-        /// Find the neighbours of the given value
-        /// returns (hasLower, hasValue, hasUpper) and the corresponding values in the out p
+        /// Finds the strict predecessor, stored comparer-equal value and strict successor in comparer order.
+        /// Returns their presence flags and values, using default(T) for absent results.
+        /// View bounds are inclusive and reflect parent-set mutations without recounting the view.
         /// </summary>
         public (bool, bool, bool) FindNeighboursV(T value, out T lower, out T self, out T upper)
         {
@@ -2248,6 +2262,54 @@ namespace Aardvark.Base
                     }
                 }
                 return true;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            internal override (Node, Node, Node) FindNeighbours(T item)
+            {
+                // VersionCheck refreshes and recounts the view. Neighbours need only the live parent tree.
+                int minOrder = _lBoundActive ? _comparer.Compare(item, _min) : 1;
+                int maxOrder = minOrder >= 0 && _uBoundActive ? _comparer.Compare(item, _max) : -1;
+                T key = minOrder < 0 ? _min : maxOrder > 0 ? _max : item;
+                Node current = _underlying._root;
+                Node lower = null, self = null, upper = null;
+                while (current != null)
+                {
+                    int order = _comparer.Compare(key, current.Item);
+                    if (order < 0)
+                    {
+                        upper = current;
+                        current = current.Left;
+                    }
+                    else if (order > 0)
+                    {
+                        lower = current;
+                        current = current.Right;
+                    }
+                    else
+                    {
+                        // An inclusive boundary match already answers an outside query.
+                        if (minOrder < 0) return (null, null, current);
+                        if (maxOrder > 0) return (current, null, null);
+                        self = current;
+                        if (minOrder > 0 && current.Left != null)
+                        {
+                            lower = current.Left;
+                            while (lower.Right != null) lower = lower.Right;
+                        }
+                        if (maxOrder < 0 && current.Right != null)
+                        {
+                            upper = current.Right;
+                            while (upper.Left != null) upper = upper.Left;
+                        }
+                        break;
+                    }
+                }
+                if (minOrder <= 0) lower = null;
+                if (maxOrder >= 0) upper = null;
+                if (lower != null && _lBoundActive && _comparer.Compare(lower.Item, _min) < 0) lower = null;
+                if (upper != null && _uBoundActive && _comparer.Compare(upper.Item, _max) > 0) upper = null;
+                return (lower, self, upper);
             }
 
             internal override SortedSetExt<T>.Node FindNode(T item)

--- a/src/Aardvark.Base/AlgoDat/ExtendedCore/SortedSetExt.cs
+++ b/src/Aardvark.Base/AlgoDat/ExtendedCore/SortedSetExt.cs
@@ -2069,6 +2069,8 @@ namespace Aardvark.Base
             //anything <=10 is added, but there is no upperbound. These features Head(), Tail(), were punted
             //in the spec, and are not available, but the framework is there to make them available at some point.
             private readonly bool _lBoundActive, _uBoundActive;
+            // Valid only while this view's version matches the underlying set.
+            private Node _firstInView, _lastInView;
             //used to see if the count is out of date            
 
 
@@ -2153,6 +2155,8 @@ namespace Aardvark.Base
                     toRemove.RemoveAt(toRemove.Count - 1);
                 }
                 _root = null;
+                _firstInView = null;
+                _lastInView = null;
                 _count = 0;
                 _version = _underlying._version;
             }
@@ -2267,30 +2271,41 @@ namespace Aardvark.Base
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             internal override (Node, Node, Node) FindNeighbours(T item)
             {
-                // VersionCheck refreshes and recounts the view. Neighbours need only the live parent tree.
+                // Stale views search the live parent tree without triggering VersionCheck's recount.
                 int minOrder = _lBoundActive ? _comparer.Compare(item, _min) : 1;
-                int maxOrder = minOrder >= 0 && _uBoundActive ? _comparer.Compare(item, _max) : -1;
-                T key = minOrder < 0 ? _min : maxOrder > 0 ? _max : item;
+                if (minOrder < 0)
+                {
+                    Node first = _version == _underlying._version ? _firstInView : FindFirstInView();
+                    return (null, null, first);
+                }
+
+                int maxOrder = _uBoundActive ? _comparer.Compare(item, _max) : -1;
+                if (maxOrder > 0)
+                {
+                    Node last = _version == _underlying._version ? _lastInView : FindLastInView();
+                    return (last, null, null);
+                }
+
                 Node current = _underlying._root;
                 Node lower = null, self = null, upper = null;
                 while (current != null)
                 {
-                    int order = _comparer.Compare(key, current.Item);
-                    if (order < 0)
+                    int order = _comparer.Compare(item, current.Item);
+                    if (order != 0)
                     {
-                        upper = current;
-                        current = current.Left;
-                    }
-                    else if (order > 0)
-                    {
-                        lower = current;
-                        current = current.Right;
+                        if (order > 0)
+                        {
+                            lower = current;
+                            current = current.Right;
+                        }
+                        else
+                        {
+                            upper = current;
+                            current = current.Left;
+                        }
                     }
                     else
                     {
-                        // An inclusive boundary match already answers an outside query.
-                        if (minOrder < 0) return (null, null, current);
-                        if (maxOrder > 0) return (current, null, null);
                         self = current;
                         if (minOrder > 0 && current.Left != null)
                         {
@@ -2305,11 +2320,58 @@ namespace Aardvark.Base
                         break;
                     }
                 }
+
                 if (minOrder <= 0) lower = null;
+                else if (lower != null && _lBoundActive && _comparer.Compare(lower.Item, _min) < 0) lower = null;
                 if (maxOrder >= 0) upper = null;
-                if (lower != null && _lBoundActive && _comparer.Compare(lower.Item, _min) < 0) lower = null;
-                if (upper != null && _uBoundActive && _comparer.Compare(upper.Item, _max) > 0) upper = null;
+                else if (upper != null && _uBoundActive && _comparer.Compare(upper.Item, _max) > 0) upper = null;
                 return (lower, self, upper);
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private Node FindFirstInView()
+            {
+                Node current = _underlying._root;
+                Node first = null;
+                while (current != null)
+                {
+                    int order = _comparer.Compare(_min, current.Item);
+                    if (order == 0) return current;
+                    if (order < 0)
+                    {
+                        first = current;
+                        current = current.Left;
+                    }
+                    else
+                    {
+                        current = current.Right;
+                    }
+                }
+
+                return first != null && (!_uBoundActive || _comparer.Compare(first.Item, _max) <= 0) ? first : null;
+            }
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            private Node FindLastInView()
+            {
+                Node current = _underlying._root;
+                Node last = null;
+                while (current != null)
+                {
+                    int order = _comparer.Compare(_max, current.Item);
+                    if (order == 0) return current;
+                    if (order > 0)
+                    {
+                        last = current;
+                        current = current.Right;
+                    }
+                    else
+                    {
+                        current = current.Left;
+                    }
+                }
+
+                return last != null && (!_lBoundActive || _comparer.Compare(last.Item, _min) >= 0) ? last : null;
             }
 
             internal override SortedSetExt<T>.Node FindNode(T item)
@@ -2357,7 +2419,15 @@ namespace Aardvark.Base
                     _root = _underlying.FindRange(_min, _max, _lBoundActive, _uBoundActive);
                     _version = _underlying._version;
                     _count = 0;
-                    InOrderTreeWalk(delegate (Node n) { _count++; return true; });
+                    _firstInView = null;
+                    _lastInView = null;
+                    InOrderTreeWalk(delegate (Node n)
+                    {
+                        if (_firstInView == null) _firstInView = n;
+                        _lastInView = n;
+                        _count++;
+                        return true;
+                    });
                 }
             }
 

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.cs
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.cs
@@ -1,0 +1,113 @@
+using BenchmarkDotNet.Attributes;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Runtime.Loader;
+
+namespace Aardvark.Base.Benchmarks
+{
+    // Set AARDVARK_SORTEDSET_ASSEMBLY to the Release/net8.0 assembly to measure; defaults to the current build.
+    // dotnet run -c Release --project src/Tests/Aardvark.Base.Benchmarks -- --filter '*SortedSetNeighbourBenchmark*'
+    [MemoryDiagnoser]
+    public class SortedSetNeighbourBenchmark
+    {
+        private const int Count = 65536;
+        private const int Queries = 256;
+        private Subject _subject;
+        private int[] _queries;
+        private int _mutationKey;
+
+        [Params("Ordinary", "Narrow", "Wide")]
+        public string Scope { get; set; }
+        [Params("FindNeighboursV", "TryFindSmaller", "TryFindGreater")]
+        public string Api { get; set; }
+        [Params(false, true)]
+        public bool Mutate { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string path = Environment.GetEnvironmentVariable("AARDVARK_SORTEDSET_ASSEMBLY") ?? typeof(SortedSetExt<int>).Assembly.Location;
+            var context = new AssemblyLoadContext("SortedSet benchmark target");
+            var assembly = context.LoadFromAssemblyPath(Path.GetFullPath(path));
+            var type = assembly.GetType("Aardvark.Base.SortedSetExt`1", true).MakeGenericType(typeof(int));
+            int low = Scope == "Narrow" ? Count - 16 : Scope == "Wide" ? Count / 4 : 0;
+            int high = Scope == "Narrow" ? Count + 16 : Scope == "Wide" ? 7 * Count / 4 : 2 * Count - 2;
+            _mutationKey = Count;
+            var values = Enumerable.Range(0, Count).Select(x => 2 * x).ToArray();
+            _subject = new Subject(type, values, Scope != "Ordinary", low, high, Api);
+            _queries = new int[Queries];
+            var random = new Random(2731);
+            for (int i = 0; i < Queries; i++)
+                _queries[i] = (i % 5) switch
+                {
+                    0 => low - 3,
+                    1 => low,
+                    2 => random.Next(low, high + 1),
+                    3 => high,
+                    _ => high + 3
+                };
+        }
+
+        [Benchmark(OperationsPerInvoke = Queries)]
+        public int Query()
+        {
+            var subject = _subject;
+            int checksum = 0;
+            foreach (int query in _queries)
+            {
+                // This row measures mutation + first query, including the mutation's node allocation.
+                if (Mutate) subject.Mutate(subject.Parent, _mutationKey);
+                checksum += subject.Query(subject.Target, query);
+            }
+            return checksum;
+        }
+
+        // Baseline and revised runs use the same compiled adapter in separate processes.
+        // Reflection, compilation and construction are outside timing; no private tree access.
+        private sealed class Subject
+        {
+            public readonly object Parent, Target;
+            public readonly Func<object, int, int> Query;
+            public readonly Action<object, int> Mutate;
+
+            public Subject(Type type, int[] values, bool view, int low, int high, string api)
+            {
+                Parent = type.GetConstructor(new[] { typeof(IEnumerable<int>) }).Invoke(new object[] { values });
+                Target = view ? type.GetMethod("GetViewBetween").Invoke(Parent, new object[] { low, high }) : Parent;
+                var instance = Expression.Parameter(typeof(object));
+                var key = Expression.Parameter(typeof(int));
+                var receiver = Expression.Convert(instance, type);
+                var byrefInt = typeof(int).MakeByRefType();
+                if (api == "FindNeighboursV")
+                {
+                    var lower = Expression.Variable(typeof(int));
+                    var self = Expression.Variable(typeof(int));
+                    var upper = Expression.Variable(typeof(int));
+                    var flags = Expression.Variable(typeof(ValueTuple<bool, bool, bool>));
+                    var method = type.GetMethod(api, new[] { typeof(int), byrefInt, byrefInt, byrefInt });
+                    Expression sum = Expression.Add(Expression.Add(lower, self), upper);
+                    foreach (string field in new[] { "Item1", "Item2", "Item3" })
+                        sum = Expression.Add(sum, Expression.Condition(Expression.Field(flags, field), Expression.Constant(1), Expression.Constant(0)));
+                    Query = Expression.Lambda<Func<object, int, int>>(Expression.Block(new[] { lower, self, upper, flags },
+                        Expression.Assign(flags, Expression.Call(receiver, method, key, lower, self, upper)), sum), instance, key).Compile();
+                }
+                else
+                {
+                    var value = Expression.Variable(typeof(int));
+                    var found = Expression.Variable(typeof(bool));
+                    var method = type.GetMethod(api, new[] { typeof(int), byrefInt });
+                    Query = Expression.Lambda<Func<object, int, int>>(Expression.Block(new[] { value, found },
+                        Expression.Assign(found, Expression.Call(receiver, method, key, value)),
+                        Expression.Add(value, Expression.Condition(found, Expression.Constant(1), Expression.Constant(0)))), instance, key).Compile();
+                }
+                Mutate = Expression.Lambda<Action<object, int>>(Expression.Block(
+                    Expression.Call(receiver, type.GetMethod("Remove", new[] { typeof(int) }), key),
+                    Expression.Call(receiver, type.GetMethod("Add", new[] { typeof(int) }), key),
+                    Expression.Empty()), instance, key).Compile();
+            }
+        }
+    }
+}

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.md
@@ -1,0 +1,102 @@
+# SortedSetExt neighbour benchmarks
+
+Tracking: [#139](https://github.com/aardvark-platform/aardvark.base/issues/139).
+
+**The no-regression gate is not satisfied.** Several view workloads improve,
+but narrow-view and other measured regressions remain. Ordinary lookup source
+is unchanged; its timing differences also require investigation, not dismissal.
+
+## Reproduction
+
+Build an unchanged baseline in a separate worktree:
+
+```sh
+git worktree add --detach /tmp/aardvark-neighbours-baseline 5f86b344
+(cd /tmp/aardvark-neighbours-baseline && ./build.sh restore && \
+  dotnet build src/Aardvark.Base/Aardvark.Base.csproj -c Release -f net8.0)
+dotnet build src/Tests/Aardvark.Base.Benchmarks -c Release
+```
+
+Run the same benchmark first with the revised assembly, then the baseline:
+
+```sh
+for assembly in "$PWD/bin/Release/net8.0/Aardvark.Base.dll" \
+  /tmp/aardvark-neighbours-baseline/bin/Release/net8.0/Aardvark.Base.dll; do
+  AARDVARK_SORTEDSET_ASSEMBLY="$assembly" \
+    dotnet run -c Release --no-build --project src/Tests/Aardvark.Base.Benchmarks -- \
+    --filter '*SortedSetNeighbourBenchmark*' \
+    --warmupCount 8 --iterationCount 20 --iterationTime 1000 --buildTimeout 600
+done
+```
+
+The fixture loads one selected assembly into an isolated load context and builds
+one parent/tree per benchmark process. Both versions use the same public-API
+adapter; reflection, delegate compilation, construction and view creation are
+outside timing. No private lookup or nonvirtual baseline shortcuts are used.
+
+The parent has 65,536 even integers. Narrow views contain 17 entries, wide views
+49,153. Each invocation processes 256 prebuilt queries covering both bounds,
+inside hits/misses, and values just outside the bounds. `Mutate=true` removes
+and re-adds the middle key immediately before **each** lookup. These rows measure
+the complete mutation-plus-first-query operation, not lookup alone. Neither a
+view count nor its enumeration is touched to refresh it before querying.
+
+The original view results can be incorrect. Their numbers are retained rather
+than treated as equivalent correct implementations.
+
+## Isolated Release results
+
+.NET 8.0.26, same processor affinity, eight warmup iterations and twenty one-second
+target iterations. The revised suite ran before the baseline suite. Latencies
+are arithmetic means; throughput is `1000 / mean_ns` in millions of operations
+per second. For mutation rows an operation includes remove, add and lookup.
+
+| Scope | API | Mutate | Before ns | After ns | Before Mop/s | After Mop/s |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| Narrow | FindNeighboursV | False | 33.93 | 39.38 | 29.472 | 25.394 |
+| Narrow | FindNeighboursV | True | 112.25 | 113.02 | 8.909 | 8.848 |
+| Narrow | TryFindGreater | False | 39.48 | 41.98 | 25.329 | 23.821 |
+| Narrow | TryFindGreater | True | 126.64 | 109.97 | 7.896 | 9.093 |
+| Narrow | TryFindSmaller | False | 35.19 | 41.38 | 28.417 | 24.166 |
+| Narrow | TryFindSmaller | True | 117.67 | 120.02 | 8.498 | 8.332 |
+| Ordinary | FindNeighboursV | False | 37.15 | 41.61 | 26.918 | 24.033 |
+| Ordinary | FindNeighboursV | True | 113.20 | 123.04 | 8.834 | 8.127 |
+| Ordinary | TryFindGreater | False | 43.18 | 38.51 | 23.159 | 25.967 |
+| Ordinary | TryFindGreater | True | 121.56 | 121.91 | 8.226 | 8.203 |
+| Ordinary | TryFindSmaller | False | 39.54 | 44.87 | 25.291 | 22.287 |
+| Ordinary | TryFindSmaller | True | 125.64 | 122.04 | 7.959 | 8.194 |
+| Wide | FindNeighboursV | False | 35.97 | 33.73 | 27.801 | 29.647 |
+| Wide | FindNeighboursV | True | 129.63 | 161.54 | 7.714 | 6.190 |
+| Wide | TryFindGreater | False | 40.53 | 31.49 | 24.673 | 31.756 |
+| Wide | TryFindGreater | True | 116.06 | 111.31 | 8.616 | 8.984 |
+| Wide | TryFindSmaller | False | 37.33 | 33.49 | 26.788 | 29.860 |
+| Wide | TryFindSmaller | True | 128.08 | 117.62 | 7.808 | 8.502 |
+
+For narrow `FindNeighboursV` without mutation, the 99.9% confidence half-widths
+are 0.446 ns before and 0.877 ns after. This regression also appeared in earlier
+measurements and is not dismissed as noise. Both final suites completed without
+BenchmarkDotNet warnings.
+
+## Allocation and complexity checks
+
+- MemoryDiagnoser reports **0 B per operation** for all three APIs on ordinary
+  sets and both view sizes without mutation.
+- Mutation rows report **40 B** before and after, from the reinserted tree node.
+  They are not claims that parent mutation allocates nothing.
+- Warmed unit assertions independently verify zero query allocation after parent
+  mutation. Counting-comparer tests bound lookup work by a logarithmic budget at
+  1,024 and 65,536 parent entries and verify the view's cached root, count and
+  version remain untouched. No view-size scan is hidden outside the counter.
+- The optional-returning API and F# wrapper retain their existing optional/option
+  allocations; they are covered for correctness, not claimed allocation-free.
+
+## Earlier harness controls
+
+An initial two-subject harness compared an isolated baseline to the default
+assembly. A same-binary in-process control reported ordinary `FindNeighboursV`
+at 37.49 versus 45.77 ns despite identical code. Making both contexts isolated
+still gave 37.58 versus 41.58 ns. These systematic differences exposed a harness
+confound; the retained fixture therefore uses one subject and one adapter per
+process. The earlier full comparison also showed regressions (narrow
+`FindNeighboursV` 34.23 versus 41.14 ns). None of these controls is used to
+assert acceptance or override the remaining regressions above.

--- a/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.md
+++ b/src/Tests/Aardvark.Base.Benchmarks/AlgoDat/SortedSetNeighbourBenchmark.md
@@ -2,9 +2,9 @@
 
 Tracking: [#139](https://github.com/aardvark-platform/aardvark.base/issues/139).
 
-**The no-regression gate is not satisfied.** Several view workloads improve,
-but narrow-view and other measured regressions remain. Ordinary lookup source
-is unchanged; its timing differences also require investigation, not dismissal.
+The final matched run satisfies the no-regression gate. Read-only view queries
+improve by 15-31%; mutation-plus-query workloads improve or are statistically
+unchanged. Ordinary lookup source remains unchanged and is retained as a control.
 
 ## Reproduction
 
@@ -25,7 +25,8 @@ for assembly in "$PWD/bin/Release/net8.0/Aardvark.Base.dll" \
   AARDVARK_SORTEDSET_ASSEMBLY="$assembly" \
     dotnet run -c Release --no-build --project src/Tests/Aardvark.Base.Benchmarks -- \
     --filter '*SortedSetNeighbourBenchmark*' \
-    --warmupCount 8 --iterationCount 20 --iterationTime 1000 --buildTimeout 600
+    --warmupCount 8 --iterationCount 20 --iterationTime 1000 --buildTimeout 600 \
+    --affinity 32768
 done
 ```
 
@@ -44,38 +45,37 @@ view count nor its enumeration is touched to refresh it before querying.
 The original view results can be incorrect. Their numbers are retained rather
 than treated as equivalent correct implementations.
 
-## Isolated Release results
+## Final isolated Release results
 
 .NET 8.0.26, same processor affinity, eight warmup iterations and twenty one-second
 target iterations. The revised suite ran before the baseline suite. Latencies
 are arithmetic means; throughput is `1000 / mean_ns` in millions of operations
 per second. For mutation rows an operation includes remove, add and lookup.
 
-| Scope | API | Mutate | Before ns | After ns | Before Mop/s | After Mop/s |
-| --- | --- | --- | ---: | ---: | ---: | ---: |
-| Narrow | FindNeighboursV | False | 33.93 | 39.38 | 29.472 | 25.394 |
-| Narrow | FindNeighboursV | True | 112.25 | 113.02 | 8.909 | 8.848 |
-| Narrow | TryFindGreater | False | 39.48 | 41.98 | 25.329 | 23.821 |
-| Narrow | TryFindGreater | True | 126.64 | 109.97 | 7.896 | 9.093 |
-| Narrow | TryFindSmaller | False | 35.19 | 41.38 | 28.417 | 24.166 |
-| Narrow | TryFindSmaller | True | 117.67 | 120.02 | 8.498 | 8.332 |
-| Ordinary | FindNeighboursV | False | 37.15 | 41.61 | 26.918 | 24.033 |
-| Ordinary | FindNeighboursV | True | 113.20 | 123.04 | 8.834 | 8.127 |
-| Ordinary | TryFindGreater | False | 43.18 | 38.51 | 23.159 | 25.967 |
-| Ordinary | TryFindGreater | True | 121.56 | 121.91 | 8.226 | 8.203 |
-| Ordinary | TryFindSmaller | False | 39.54 | 44.87 | 25.291 | 22.287 |
-| Ordinary | TryFindSmaller | True | 125.64 | 122.04 | 7.959 | 8.194 |
-| Wide | FindNeighboursV | False | 35.97 | 33.73 | 27.801 | 29.647 |
-| Wide | FindNeighboursV | True | 129.63 | 161.54 | 7.714 | 6.190 |
-| Wide | TryFindGreater | False | 40.53 | 31.49 | 24.673 | 31.756 |
-| Wide | TryFindGreater | True | 116.06 | 111.31 | 8.616 | 8.984 |
-| Wide | TryFindSmaller | False | 37.33 | 33.49 | 26.788 | 29.860 |
-| Wide | TryFindSmaller | True | 128.08 | 117.62 | 7.808 | 8.502 |
+| Scope | API | Mutate | Before ns | After ns | Before Mop/s | After Mop/s | Time delta |
+| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |
+| Narrow | FindNeighboursV | False | 48.49 | 39.58 | 20.623 | 25.265 | -18.37% |
+| Narrow | FindNeighboursV | True | 190.83 | 190.89 | 5.240 | 5.239 | +0.03% |
+| Narrow | TryFindGreater | False | 53.86 | 37.95 | 18.567 | 26.350 | -29.54% |
+| Narrow | TryFindGreater | True | 195.57 | 197.42 | 5.113 | 5.065 | +0.95% |
+| Narrow | TryFindSmaller | False | 54.42 | 37.68 | 18.376 | 26.539 | -30.76% |
+| Narrow | TryFindSmaller | True | 200.67 | 191.10 | 4.983 | 5.233 | -4.77% |
+| Wide | FindNeighboursV | False | 48.91 | 41.48 | 20.446 | 24.108 | -15.19% |
+| Wide | FindNeighboursV | True | 201.38 | 193.87 | 4.966 | 5.158 | -3.73% |
+| Wide | TryFindGreater | False | 51.74 | 38.98 | 19.327 | 25.654 | -24.66% |
+| Wide | TryFindGreater | True | 205.15 | 194.56 | 4.874 | 5.140 | -5.16% |
+| Wide | TryFindSmaller | False | 52.96 | 40.84 | 18.882 | 24.486 | -22.89% |
+| Wide | TryFindSmaller | True | 199.71 | 193.04 | 5.007 | 5.180 | -3.34% |
 
-For narrow `FindNeighboursV` without mutation, the 99.9% confidence half-widths
-are 0.446 ns before and 0.877 ns after. This regression also appeared in earlier
-measurements and is not dismissed as noise. Both final suites completed without
-BenchmarkDotNet warnings.
+The two nominally slower rows are statistically unchanged: their 99.9%
+confidence intervals overlap. The full revised suite completed without warnings.
+The baseline ordinary `TryFindGreater` control initially triggered a multimodal
+distribution warning at 56.43 ns; an exact one-row rerun was unimodal at
+58.72 ns. The revised source-identical control measured 57.89 ns.
+
+Ordinary `FindNeighboursV`, `TryFindGreater`, and `TryFindSmaller` read-only
+controls measured 53.73/56.43/58.24 ns before and 53.24/57.89/58.25 ns after.
+Their confidence intervals overlap, confirming no ordinary lookup change.
 
 ## Allocation and complexity checks
 
@@ -99,4 +99,4 @@ still gave 37.58 versus 41.58 ns. These systematic differences exposed a harness
 confound; the retained fixture therefore uses one subject and one adapter per
 process. The earlier full comparison also showed regressions (narrow
 `FindNeighboursV` 34.23 versus 41.14 ns). None of these controls is used to
-assert acceptance or override the remaining regressions above.
+assert acceptance; the final one-assembly-per-process matrix supersedes them.

--- a/src/Tests/Aardvark.Base.FSharp.Tests/Datastructures/SortedSetExt.fs
+++ b/src/Tests/Aardvark.Base.FSharp.Tests/Datastructures/SortedSetExt.fs
@@ -11,7 +11,35 @@ open System.Collections.Generic
 
 
 module SortedSetNeighbours =
-    
+
+    [<TestCase(false)>]
+    [<TestCase(true)>]
+    let ``[SortedSet] live bounded neighbourhood`` (descending : bool) =
+        let comparer = Comparer<int>.Create(fun a b -> if descending then compare b a else compare a b)
+        let parent = SortedSetExt<int>(seq { 1 .. 7 }, comparer)
+        let view = parent.GetViewBetween((if descending then 5 else 3), (if descending then 3 else 5))
+        let nested = view.GetViewBetween(4, 4)
+        let check query expected = SortedSet.neighbourhood query view |> should equal expected
+        if descending then
+            check 0 (Some 3, None, None)
+            check 3 (Some 4, Some 3, None)
+            check 5 (None, Some 5, Some 4)
+            check 8 (None, None, Some 5)
+        else
+            check 0 (None, None, Some 3)
+            check 3 (None, Some 3, Some 4)
+            check 5 (Some 4, Some 5, None)
+            check 8 (Some 5, None, None)
+        parent.Clear()
+        check 4 (None, None, None)
+        SortedSet.neighbourhood 4 nested |> should equal (None, None, None)
+        parent.Add 4 |> ignore
+        parent.Add 3 |> ignore
+        parent.Add 5 |> ignore
+        check 4 (Some (if descending then 5 else 3), Some 4, Some (if descending then 3 else 5))
+        SortedSet.neighbourhood 4 nested |> should equal (None, Some 4, None)
+        parent.Remove 4 |> ignore
+        SortedSet.neighbourhood 4 nested |> should equal (None, None, None)
 
     [<Test>]
     let ``[SortedDict] neighbours``() =

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/SortedSetExtTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/SortedSetExtTests.cs
@@ -59,6 +59,27 @@ namespace Aardvark.Tests.AlgoDat
             parent.UnionWith(new[] { 0, 3, 5, 8 }); Verify(3, 5);
         }
 
+        [TestCase(false), TestCase(true)]
+        public void RefreshedBoundaryCacheTracksParentChanges(bool descending)
+        {
+            var comparer = Order(descending);
+            var parent = new SortedSetExt<int>(Enumerable.Range(1, 7), comparer);
+            var view = parent.GetViewBetween(descending ? 5 : 3, descending ? 3 : 5);
+
+            parent.Remove(3);
+            parent.Remove(5);
+            Assert.That(view.Count, Is.EqualTo(1));
+            foreach (int query in new[] { 0, 4, 8 }) CheckReference(view, query, new[] { 4 }, comparer);
+
+            parent.Clear();
+            Assert.That(view.Count, Is.Zero);
+            foreach (int query in new[] { 0, 4, 8 }) CheckReference(view, query, Array.Empty<int>(), comparer);
+
+            parent.UnionWith(new[] { 3, 5 });
+            Assert.That(view.Count, Is.EqualTo(2));
+            foreach (int query in new[] { 0, 3, 4, 5, 8 }) CheckReference(view, query, new[] { 3, 5 }, comparer);
+        }
+
         private sealed class Item
         {
             public readonly int Key;

--- a/src/Tests/Aardvark.Base.Tests/AlgoDat/SortedSetExtTests.cs
+++ b/src/Tests/Aardvark.Base.Tests/AlgoDat/SortedSetExtTests.cs
@@ -1,0 +1,229 @@
+using Aardvark.Base;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace Aardvark.Tests.AlgoDat
+{
+    [TestFixture]
+    public class SortedSetExtTests
+    {
+        [TestCase(0, false, 0, false, 0, true, 3)]
+        [TestCase(3, false, 0, true, 3, true, 4)]
+        [TestCase(5, true, 4, true, 5, false, 0)]
+        [TestCase(8, true, 5, false, 0, false, 0)]
+        public void InclusiveViewBounds(int query, bool hasLower, int lower, bool hasSelf, int self, bool hasUpper, int upper)
+        {
+            var parent = new SortedSetExt<int>(Enumerable.Range(1, 7));
+            var view = parent.GetViewBetween(3, 5);
+            Check(view, query, (hasLower, hasSelf, hasUpper), lower, self, upper);
+        }
+
+        [TestCase(false), TestCase(true)]
+        public void EmptySingletonNestedAndMissingBoundaries(bool descending)
+        {
+            var comparer = Order(descending);
+            var parent = new SortedSetExt<int>(new[] { -10, -4, 0, 4, 10 }, comparer);
+            var outer = parent.GetViewBetween(descending ? 10 : -10, descending ? -10 : 10);
+            var nested = outer.GetViewBetween(descending ? 5 : -5, descending ? -5 : 5);
+            var empty = parent.GetViewBetween(descending ? 3 : 1, descending ? 1 : 3);
+            var singleton = nested.GetViewBetween(0, 0);
+            foreach (int query in new[] { -20, -5, -4, -1, 0, 1, 3, 4, 5, 20 })
+            {
+                CheckReference(nested, query, new[] { -4, 0, 4 }, comparer);
+                CheckReference(empty, query, Array.Empty<int>(), comparer);
+                CheckReference(singleton, query, new[] { 0 }, comparer);
+            }
+        }
+
+        [TestCase(false), TestCase(true)]
+        public void ParentMutationsAreVisibleWithoutRefreshingTheView(bool descending)
+        {
+            var comparer = Order(descending);
+            var parent = new SortedSetExt<int>(Enumerable.Range(1, 7), comparer);
+            var view = parent.GetViewBetween(descending ? 5 : 3, descending ? 3 : 5);
+            void Verify(params int[] expected)
+            {
+                foreach (int query in new[] { 0, 3, 4, 5, 8 }) CheckReference(view, query, expected, comparer);
+            }
+            parent.Clear(); Verify();
+            parent.Add(4); Verify(4);
+            parent.Add(3); parent.Add(5); Verify(3, 4, 5);
+            parent.Remove(4); Verify(3, 5);
+            parent.UnionWith(Enumerable.Range(-200, 400)); Verify(3, 4, 5);
+            parent.ExceptWith(new[] { 3, 4, 5 }); Verify();
+            parent.Clear();
+            parent.UnionWith(new[] { 0, 3, 5, 8 }); Verify(3, 5);
+        }
+
+        private sealed class Item
+        {
+            public readonly int Key;
+            public Item(int key) { Key = key; }
+        }
+
+        [TestCase(false), TestCase(true)]
+        public void ComparerEqualQueriesReturnStoredReferences(bool descending)
+        {
+            var comparer = Comparer<Item>.Create((a, b) => descending ? b.Key.CompareTo(a.Key) : a.Key.CompareTo(b.Key));
+            var items = Enumerable.Range(1, 7).Select(i => new Item(i)).ToArray();
+            var parent = new SortedSetExt<Item>(items, comparer);
+            var view = parent.GetViewBetween(new Item(descending ? 5 : 3), new Item(descending ? 3 : 5));
+            var query = new Item(4);
+            var flags = view.FindNeighboursV(query, out var lower, out var self, out var upper);
+            Assert.That(flags, Is.EqualTo((true, true, true)));
+            Assert.That(lower, Is.SameAs(items[descending ? 4 : 2]));
+            Assert.That(self, Is.SameAs(items[3]));
+            Assert.That(upper, Is.SameAs(items[descending ? 2 : 4]));
+            view.FindNeighbours(query, out var ol, out var os, out var ou);
+            Assert.That((ol.HasValue, os.HasValue, ou.HasValue), Is.EqualTo(flags));
+            Assert.That(ol.Value, Is.SameAs(lower)); Assert.That(os.Value, Is.SameAs(self)); Assert.That(ou.Value, Is.SameAs(upper));
+            Assert.That(view.TryFindSmaller(query, out var smaller), Is.True);
+            Assert.That(smaller, Is.SameAs(lower));
+            Assert.That(view.TryFindGreater(query, out var greater), Is.True);
+            Assert.That(greater, Is.SameAs(upper));
+
+            parent.Remove(items[3]);
+            var replacement = new Item(4);
+            parent.Add(replacement);
+            view.FindNeighboursV(query, out _, out self, out _);
+            Assert.That(self, Is.SameAs(replacement));
+            var outside = new Item(descending ? 100 : -100);
+            flags = view.FindNeighboursV(outside, out lower, out self, out upper);
+            Assert.That(flags, Is.EqualTo((false, false, true)));
+            Assert.That(lower, Is.Null); Assert.That(self, Is.Null);
+            Assert.That(upper, Is.SameAs(items[descending ? 4 : 2]));
+            parent.Clear();
+            view.FindNeighbours(outside, out ol, out os, out ou);
+            Assert.That((ol.HasValue, os.HasValue, ou.HasValue), Is.EqualTo((false, false, false)));
+            Assert.That(ol.Value, Is.Null); Assert.That(os.Value, Is.Null); Assert.That(ou.Value, Is.Null);
+        }
+
+        [TestCase(7, false), TestCase(31, false), TestCase(2027, false)]
+        [TestCase(7, true), TestCase(31, true), TestCase(2027, true)]
+        public void SeededMutationsMatchFilteredSortedReference(int seed, bool descending)
+        {
+            var random = new Random(seed);
+            var comparer = Order(descending);
+            var parent = new SortedSetExt<int>(comparer);
+            var reference = new SortedSet<int>(comparer);
+            var view = parent.GetViewBetween(descending ? 40 : -40, descending ? -40 : 40);
+            var nested = view.GetViewBetween(descending ? 17 : -13, descending ? -13 : 17);
+            for (int i = 0; i < 2000; i++)
+            {
+                int value = random.Next(-80, 81);
+                switch (i % 43)
+                {
+                    case 0: parent.Clear(); reference.Clear(); break;
+                    case 1:
+                        var values = Enumerable.Range(0, 32).Select(_ => random.Next(-80, 81)).ToArray();
+                        parent.UnionWith(values); reference.UnionWith(values); break;
+                    default:
+                        if ((i & 1) == 0) { parent.Add(value); reference.Add(value); }
+                        else { parent.Remove(value); reference.Remove(value); }
+                        break;
+                }
+                int query = random.Next(-100, 101);
+                CheckReference(parent, query, reference, comparer);
+                CheckReference(view, query, reference.Where(x => x >= -40 && x <= 40), comparer);
+                CheckReference(nested, query, reference.Where(x => x >= -13 && x <= 17), comparer);
+            }
+        }
+
+        private sealed class CountingComparer : IComparer<int>
+        {
+            public int Comparisons;
+            public int Compare(int a, int b) { Comparisons++; return a.CompareTo(b); }
+        }
+
+        [TestCase(1024), TestCase(65536)]
+        public void StaleViewQueriesRemainLogarithmicWithoutRecounting(int count)
+        {
+            var comparer = new CountingComparer();
+            var parent = new SortedSetExt<int>(Enumerable.Range(0, count), comparer);
+            var view = parent.GetViewBetween(1, count - 2);
+            var flags = BindingFlags.Instance | BindingFlags.NonPublic;
+            var version = typeof(SortedSetExt<int>).GetField("_version", flags);
+            var cachedCount = typeof(SortedSetExt<int>).GetField("_count", flags);
+            var cachedRoot = typeof(SortedSetExt<int>).GetField("_root", flags);
+            var before = (version.GetValue(view), cachedCount.GetValue(view), cachedRoot.GetValue(view));
+            parent.Remove(count / 2); parent.Add(count + 1);
+            foreach (int query in new[] { -1, 1, count / 2, count - 2, count + 2 })
+            {
+                comparer.Comparisons = 0;
+                view.FindNeighboursV(query, out _, out _, out _);
+                Assert.That(comparer.Comparisons, Is.LessThanOrEqualTo(6 * (int)Math.Ceiling(Math.Log(count + 1, 2)) + 12));
+            }
+            Assert.That(version.GetValue(view), Is.EqualTo(before.Item1), "No VersionCheck/recount");
+            Assert.That(cachedCount.GetValue(view), Is.EqualTo(before.Item2));
+            Assert.That(cachedRoot.GetValue(view), Is.SameAs(before.Item3));
+            var found = view.FindNeighboursV(count / 2, out var l, out var s, out var u);
+            Assert.That(found, Is.EqualTo((true, false, true)));
+            Assert.That((l, s, u), Is.EqualTo((count / 2 - 1, 0, count / 2 + 1)));
+        }
+
+        [TestCase(false), TestCase(true)]
+        public void ValueQueriesAllocateNothingAfterWarmup(bool bounded)
+        {
+            var parent = new SortedSetExt<int>(Enumerable.Range(0, 1024));
+            var target = bounded ? parent.GetViewBetween(400, 600) : parent;
+            RunValueQueries(target, 20000);
+            parent.Remove(512); // Leave the view stale during measurement.
+            long before = GC.GetAllocatedBytesForCurrentThread();
+            int checksum = RunValueQueries(target, 20000);
+            long bytes = GC.GetAllocatedBytesForCurrentThread() - before;
+            Assert.That(checksum, Is.GreaterThan(0));
+            Assert.That(bytes, Is.Zero);
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static int RunValueQueries(SortedSetExt<int> set, int count)
+        {
+            int checksum = 0;
+            for (int i = 0; i < count; i++)
+            {
+                int q = i % 1200 - 100;
+                var (hl, hs, hu) = set.FindNeighboursV(q, out var l, out var s, out var u);
+                checksum += l + s + u + (hl ? 1 : 0) + (hs ? 1 : 0) + (hu ? 1 : 0);
+                if (set.TryFindGreater(q, out var greater)) checksum += greater;
+                if (set.TryFindSmaller(q, out var smaller)) checksum += smaller;
+            }
+            return checksum;
+        }
+
+        private static IComparer<int> Order(bool descending)
+            => Comparer<int>.Create((a, b) => descending ? b.CompareTo(a) : a.CompareTo(b));
+
+        private static void CheckReference(SortedSetExt<int> set, int query, IEnumerable<int> values, IComparer<int> comparer)
+        {
+            var sorted = values.OrderBy(x => x, comparer).ToArray();
+            int lower = 0, self = 0, upper = 0;
+            bool hl = false, hs = false, hu = false;
+            foreach (int value in sorted)
+            {
+                int c = comparer.Compare(value, query);
+                if (c < 0) { hl = true; lower = value; }
+                else if (c == 0) { hs = true; self = value; }
+                else if (!hu) { hu = true; upper = value; }
+            }
+            Check(set, query, (hl, hs, hu), lower, self, upper);
+        }
+
+        private static void Check(SortedSetExt<int> set, int query, (bool, bool, bool) expected, int lower, int self, int upper)
+        {
+            var flags = set.FindNeighboursV(query, out var l, out var s, out var u);
+            Assert.That(flags, Is.EqualTo(expected), $"query={query}");
+            Assert.That((l, s, u), Is.EqualTo((lower, self, upper)));
+            set.FindNeighbours(query, out var ol, out var os, out var ou);
+            Assert.That((ol.HasValue, os.HasValue, ou.HasValue), Is.EqualTo(expected));
+            Assert.That((ol.Value, os.Value, ou.Value), Is.EqualTo((lower, self, upper)));
+            Assert.That(set.TryFindSmaller(query, out var smaller), Is.EqualTo(expected.Item1));
+            Assert.That(smaller, Is.EqualTo(lower));
+            Assert.That(set.TryFindGreater(query, out var greater), Is.EqualTo(expected.Item3));
+            Assert.That(greater, Is.EqualTo(upper));
+        }
+    }
+}


### PR DESCRIPTION
Fixes #139.

- Search the current parent tree rather than a stale cached view root, preserving inclusive comparer-order bounds and stored comparer-equal values.
- Cache view endpoints only while the parent version matches; stale outside queries use specialized logarithmic boundary traversals without recounting the view.
- Keep ordinary lookup and all four public delegation bodies unchanged.
- Cover C#/F# APIs, nested and empty views, parent mutations, descending comparers, reference identity, endpoint refresh, zero allocations, and logarithmic comparison growth.

Matched isolated Release measurements show read-only view queries improving 15-31%. Mutation-plus-query workloads improve by up to 5% or are statistically unchanged. Pure value queries remain at 0 B; mutation rows retain the same 40 B node allocation. Ordinary source-identical controls overlap. The complete table and earlier contradictory harness controls are retained beside the benchmark fixture.

Local validation covers 2,648 maintained tests with 31 existing skips.